### PR TITLE
Sklearn renamed get_feature_names() method of DictVectorizer class to get_feature_names_out()

### DIFF
--- a/course-zoomcamp/03-classification/notebook.ipynb
+++ b/course-zoomcamp/03-classification/notebook.ipynb
@@ -1,3948 +1,4365 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# 3. Machine Learning for Classification\n",
-    "\n",
-    "We'll use logistic regression to predict churn\n",
-    "\n",
-    "\n",
-    "## 3.1 Churn prediction project\n",
-    "\n",
-    "* Dataset: https://www.kaggle.com/blastchar/telco-customer-churn\n",
-    "* https://raw.githubusercontent.com/alexeygrigorev/mlbookcamp-code/master/chapter-03-churn-prediction/WA_Fn-UseC_-Telco-Customer-Churn.csv\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.2 Data preparation\n",
-    "\n",
-    "* Download the data, read it with pandas\n",
-    "* Look at the data\n",
-    "* Make column names and values look uniform\n",
-    "* Check if all the columns read correctly\n",
-    "* Check if the churn variable needs any preparation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "import numpy as np\n",
-    "\n",
-    "import matplotlib.pyplot as plt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data = 'https://raw.githubusercontent.com/alexeygrigorev/mlbookcamp-code/master/chapter-03-churn-prediction/WA_Fn-UseC_-Telco-Customer-Churn.csv'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--2021-09-17 21:42:33--  https://raw.githubusercontent.com/alexeygrigorev/mlbookcamp-code/master/chapter-03-churn-prediction/WA_Fn-UseC_-Telco-Customer-Churn.csv\n",
-      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.109.133, 185.199.110.133, 185.199.108.133, ...\n",
-      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.109.133|:443... connected.\n",
-      "HTTP request sent, awaiting response... 200 OK\n",
-      "Length: 977501 (955K) [text/plain]\n",
-      "Saving to: ‘data-week-3.csv’\n",
-      "\n",
-      "data-week-3.csv     100%[===================>] 954,59K  --.-KB/s    in 0,1s    \n",
-      "\n",
-      "2021-09-17 21:42:33 (8,64 MB/s) - ‘data-week-3.csv’ saved [977501/977501]\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "!wget $data -O data-week-3.csv "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>customerID</th>\n",
-       "      <th>gender</th>\n",
-       "      <th>SeniorCitizen</th>\n",
-       "      <th>Partner</th>\n",
-       "      <th>Dependents</th>\n",
-       "      <th>tenure</th>\n",
-       "      <th>PhoneService</th>\n",
-       "      <th>MultipleLines</th>\n",
-       "      <th>InternetService</th>\n",
-       "      <th>OnlineSecurity</th>\n",
-       "      <th>...</th>\n",
-       "      <th>DeviceProtection</th>\n",
-       "      <th>TechSupport</th>\n",
-       "      <th>StreamingTV</th>\n",
-       "      <th>StreamingMovies</th>\n",
-       "      <th>Contract</th>\n",
-       "      <th>PaperlessBilling</th>\n",
-       "      <th>PaymentMethod</th>\n",
-       "      <th>MonthlyCharges</th>\n",
-       "      <th>TotalCharges</th>\n",
-       "      <th>Churn</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>7590-VHVEG</td>\n",
-       "      <td>Female</td>\n",
-       "      <td>0</td>\n",
-       "      <td>Yes</td>\n",
-       "      <td>No</td>\n",
-       "      <td>1</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No phone service</td>\n",
-       "      <td>DSL</td>\n",
-       "      <td>No</td>\n",
-       "      <td>...</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>Month-to-month</td>\n",
-       "      <td>Yes</td>\n",
-       "      <td>Electronic check</td>\n",
-       "      <td>29.85</td>\n",
-       "      <td>29.85</td>\n",
-       "      <td>No</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>5575-GNVDE</td>\n",
-       "      <td>Male</td>\n",
-       "      <td>0</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>34</td>\n",
-       "      <td>Yes</td>\n",
-       "      <td>No</td>\n",
-       "      <td>DSL</td>\n",
-       "      <td>Yes</td>\n",
-       "      <td>...</td>\n",
-       "      <td>Yes</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>One year</td>\n",
-       "      <td>No</td>\n",
-       "      <td>Mailed check</td>\n",
-       "      <td>56.95</td>\n",
-       "      <td>1889.5</td>\n",
-       "      <td>No</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3668-QPYBK</td>\n",
-       "      <td>Male</td>\n",
-       "      <td>0</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>2</td>\n",
-       "      <td>Yes</td>\n",
-       "      <td>No</td>\n",
-       "      <td>DSL</td>\n",
-       "      <td>Yes</td>\n",
-       "      <td>...</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>Month-to-month</td>\n",
-       "      <td>Yes</td>\n",
-       "      <td>Mailed check</td>\n",
-       "      <td>53.85</td>\n",
-       "      <td>108.15</td>\n",
-       "      <td>Yes</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>7795-CFOCW</td>\n",
-       "      <td>Male</td>\n",
-       "      <td>0</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>45</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No phone service</td>\n",
-       "      <td>DSL</td>\n",
-       "      <td>Yes</td>\n",
-       "      <td>...</td>\n",
-       "      <td>Yes</td>\n",
-       "      <td>Yes</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>One year</td>\n",
-       "      <td>No</td>\n",
-       "      <td>Bank transfer (automatic)</td>\n",
-       "      <td>42.30</td>\n",
-       "      <td>1840.75</td>\n",
-       "      <td>No</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>9237-HQITU</td>\n",
-       "      <td>Female</td>\n",
-       "      <td>0</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>2</td>\n",
-       "      <td>Yes</td>\n",
-       "      <td>No</td>\n",
-       "      <td>Fiber optic</td>\n",
-       "      <td>No</td>\n",
-       "      <td>...</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>No</td>\n",
-       "      <td>Month-to-month</td>\n",
-       "      <td>Yes</td>\n",
-       "      <td>Electronic check</td>\n",
-       "      <td>70.70</td>\n",
-       "      <td>151.65</td>\n",
-       "      <td>Yes</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>5 rows × 21 columns</p>\n",
-       "</div>"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DYttExiRF5zk"
+      },
+      "source": [
+        "# 3. Machine Learning for Classification\n",
+        "\n",
+        "We'll use logistic regression to predict churn\n",
+        "\n",
+        "\n",
+        "## 3.1 Churn prediction project\n",
+        "\n",
+        "* Dataset: https://www.kaggle.com/blastchar/telco-customer-churn\n",
+        "* https://raw.githubusercontent.com/alexeygrigorev/mlbookcamp-code/master/chapter-03-churn-prediction/WA_Fn-UseC_-Telco-Customer-Churn.csv\n"
       ],
-      "text/plain": [
-       "   customerID  gender  SeniorCitizen Partner Dependents  tenure PhoneService  \\\n",
-       "0  7590-VHVEG  Female              0     Yes         No       1           No   \n",
-       "1  5575-GNVDE    Male              0      No         No      34          Yes   \n",
-       "2  3668-QPYBK    Male              0      No         No       2          Yes   \n",
-       "3  7795-CFOCW    Male              0      No         No      45           No   \n",
-       "4  9237-HQITU  Female              0      No         No       2          Yes   \n",
-       "\n",
-       "      MultipleLines InternetService OnlineSecurity  ... DeviceProtection  \\\n",
-       "0  No phone service             DSL             No  ...               No   \n",
-       "1                No             DSL            Yes  ...              Yes   \n",
-       "2                No             DSL            Yes  ...               No   \n",
-       "3  No phone service             DSL            Yes  ...              Yes   \n",
-       "4                No     Fiber optic             No  ...               No   \n",
-       "\n",
-       "  TechSupport StreamingTV StreamingMovies        Contract PaperlessBilling  \\\n",
-       "0          No          No              No  Month-to-month              Yes   \n",
-       "1          No          No              No        One year               No   \n",
-       "2          No          No              No  Month-to-month              Yes   \n",
-       "3         Yes          No              No        One year               No   \n",
-       "4          No          No              No  Month-to-month              Yes   \n",
-       "\n",
-       "               PaymentMethod MonthlyCharges  TotalCharges Churn  \n",
-       "0           Electronic check          29.85         29.85    No  \n",
-       "1               Mailed check          56.95        1889.5    No  \n",
-       "2               Mailed check          53.85        108.15   Yes  \n",
-       "3  Bank transfer (automatic)          42.30       1840.75    No  \n",
-       "4           Electronic check          70.70        151.65   Yes  \n",
-       "\n",
-       "[5 rows x 21 columns]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df = pd.read_csv('data-week-3.csv')\n",
-    "df.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.columns = df.columns.str.lower().str.replace(' ', '_')\n",
-    "\n",
-    "categorical_columns = list(df.dtypes[df.dtypes == 'object'].index)\n",
-    "\n",
-    "for c in categorical_columns:\n",
-    "    df[c] = df[c].str.lower().str.replace(' ', '_')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
+      "id": "DYttExiRF5zk"
+    },
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>0</th>\n",
-       "      <th>1</th>\n",
-       "      <th>2</th>\n",
-       "      <th>3</th>\n",
-       "      <th>4</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>customerid</th>\n",
-       "      <td>7590-vhveg</td>\n",
-       "      <td>5575-gnvde</td>\n",
-       "      <td>3668-qpybk</td>\n",
-       "      <td>7795-cfocw</td>\n",
-       "      <td>9237-hqitu</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>gender</th>\n",
-       "      <td>female</td>\n",
-       "      <td>male</td>\n",
-       "      <td>male</td>\n",
-       "      <td>male</td>\n",
-       "      <td>female</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>seniorcitizen</th>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>partner</th>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>dependents</th>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>tenure</th>\n",
-       "      <td>1</td>\n",
-       "      <td>34</td>\n",
-       "      <td>2</td>\n",
-       "      <td>45</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>phoneservice</th>\n",
-       "      <td>no</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "      <td>yes</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>multiplelines</th>\n",
-       "      <td>no_phone_service</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no_phone_service</td>\n",
-       "      <td>no</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>internetservice</th>\n",
-       "      <td>dsl</td>\n",
-       "      <td>dsl</td>\n",
-       "      <td>dsl</td>\n",
-       "      <td>dsl</td>\n",
-       "      <td>fiber_optic</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>onlinesecurity</th>\n",
-       "      <td>no</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>onlinebackup</th>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>deviceprotection</th>\n",
-       "      <td>no</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>techsupport</th>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>streamingtv</th>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>streamingmovies</th>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>contract</th>\n",
-       "      <td>month-to-month</td>\n",
-       "      <td>one_year</td>\n",
-       "      <td>month-to-month</td>\n",
-       "      <td>one_year</td>\n",
-       "      <td>month-to-month</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>paperlessbilling</th>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "      <td>yes</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>paymentmethod</th>\n",
-       "      <td>electronic_check</td>\n",
-       "      <td>mailed_check</td>\n",
-       "      <td>mailed_check</td>\n",
-       "      <td>bank_transfer_(automatic)</td>\n",
-       "      <td>electronic_check</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>monthlycharges</th>\n",
-       "      <td>29.85</td>\n",
-       "      <td>56.95</td>\n",
-       "      <td>53.85</td>\n",
-       "      <td>42.3</td>\n",
-       "      <td>70.7</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>totalcharges</th>\n",
-       "      <td>29.85</td>\n",
-       "      <td>1889.5</td>\n",
-       "      <td>108.15</td>\n",
-       "      <td>1840.75</td>\n",
-       "      <td>151.65</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>churn</th>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "      <td>yes</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WpM9k0uOF5zm"
+      },
+      "source": [
+        "## 3.2 Data preparation\n",
+        "\n",
+        "* Download the data, read it with pandas\n",
+        "* Look at the data\n",
+        "* Make column names and values look uniform\n",
+        "* Check if all the columns read correctly\n",
+        "* Check if the churn variable needs any preparation"
       ],
-      "text/plain": [
-       "                                 0             1               2  \\\n",
-       "customerid              7590-vhveg    5575-gnvde      3668-qpybk   \n",
-       "gender                      female          male            male   \n",
-       "seniorcitizen                    0             0               0   \n",
-       "partner                        yes            no              no   \n",
-       "dependents                      no            no              no   \n",
-       "tenure                           1            34               2   \n",
-       "phoneservice                    no           yes             yes   \n",
-       "multiplelines     no_phone_service            no              no   \n",
-       "internetservice                dsl           dsl             dsl   \n",
-       "onlinesecurity                  no           yes             yes   \n",
-       "onlinebackup                   yes            no             yes   \n",
-       "deviceprotection                no           yes              no   \n",
-       "techsupport                     no            no              no   \n",
-       "streamingtv                     no            no              no   \n",
-       "streamingmovies                 no            no              no   \n",
-       "contract            month-to-month      one_year  month-to-month   \n",
-       "paperlessbilling               yes            no             yes   \n",
-       "paymentmethod     electronic_check  mailed_check    mailed_check   \n",
-       "monthlycharges               29.85         56.95           53.85   \n",
-       "totalcharges                 29.85        1889.5          108.15   \n",
-       "churn                           no            no             yes   \n",
-       "\n",
-       "                                          3                 4  \n",
-       "customerid                       7795-cfocw        9237-hqitu  \n",
-       "gender                                 male            female  \n",
-       "seniorcitizen                             0                 0  \n",
-       "partner                                  no                no  \n",
-       "dependents                               no                no  \n",
-       "tenure                                   45                 2  \n",
-       "phoneservice                             no               yes  \n",
-       "multiplelines              no_phone_service                no  \n",
-       "internetservice                         dsl       fiber_optic  \n",
-       "onlinesecurity                          yes                no  \n",
-       "onlinebackup                             no                no  \n",
-       "deviceprotection                        yes                no  \n",
-       "techsupport                             yes                no  \n",
-       "streamingtv                              no                no  \n",
-       "streamingmovies                          no                no  \n",
-       "contract                           one_year    month-to-month  \n",
-       "paperlessbilling                         no               yes  \n",
-       "paymentmethod     bank_transfer_(automatic)  electronic_check  \n",
-       "monthlycharges                         42.3              70.7  \n",
-       "totalcharges                        1840.75            151.65  \n",
-       "churn                                    no               yes  "
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df.head().T"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tc = pd.to_numeric(df.totalcharges, errors='coerce')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.totalcharges = pd.to_numeric(df.totalcharges, errors='coerce')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.totalcharges = df.totalcharges.fillna(0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
+      "id": "WpM9k0uOF5zm"
+    },
     {
-     "data": {
-      "text/plain": [
-       "0     no\n",
-       "1     no\n",
-       "2    yes\n",
-       "3     no\n",
-       "4    yes\n",
-       "Name: churn, dtype: object"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df.churn.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.churn = (df.churn == 'yes').astype(int)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.3 Setting up the validation framework\n",
-    "\n",
-    "* Perform the train/validation/test split with Scikit-Learn"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.model_selection import train_test_split"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_full_train, df_test = train_test_split(df, test_size=0.2, random_state=1)\n",
-    "df_train, df_val = train_test_split(df_full_train, test_size=0.25, random_state=1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(4225, 1409, 1409)"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "len(df_train), len(df_val), len(df_test)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_train = df_train.reset_index(drop=True)\n",
-    "df_val = df_val.reset_index(drop=True)\n",
-    "df_test = df_test.reset_index(drop=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "y_train = df_train.churn.values\n",
-    "y_val = df_val.churn.values\n",
-    "y_test = df_test.churn.values\n",
-    "\n",
-    "del df_train['churn']\n",
-    "del df_val['churn']\n",
-    "del df_test['churn']"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.4 EDA\n",
-    "\n",
-    "* Check missing values\n",
-    "* Look at the target variable (churn)\n",
-    "* Look at numerical and categorical variables"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_full_train = df_full_train.reset_index(drop=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "customerid          0\n",
-       "gender              0\n",
-       "seniorcitizen       0\n",
-       "partner             0\n",
-       "dependents          0\n",
-       "tenure              0\n",
-       "phoneservice        0\n",
-       "multiplelines       0\n",
-       "internetservice     0\n",
-       "onlinesecurity      0\n",
-       "onlinebackup        0\n",
-       "deviceprotection    0\n",
-       "techsupport         0\n",
-       "streamingtv         0\n",
-       "streamingmovies     0\n",
-       "contract            0\n",
-       "paperlessbilling    0\n",
-       "paymentmethod       0\n",
-       "monthlycharges      0\n",
-       "totalcharges        0\n",
-       "churn               0\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_full_train.isnull().sum()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0    0.730032\n",
-       "1    0.269968\n",
-       "Name: churn, dtype: float64"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_full_train.churn.value_counts(normalize=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.26996805111821087"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_full_train.churn.mean()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "numerical = ['tenure', 'monthlycharges', 'totalcharges']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "categorical = [\n",
-    "    'gender',\n",
-    "    'seniorcitizen',\n",
-    "    'partner',\n",
-    "    'dependents',\n",
-    "    'phoneservice',\n",
-    "    'multiplelines',\n",
-    "    'internetservice',\n",
-    "    'onlinesecurity',\n",
-    "    'onlinebackup',\n",
-    "    'deviceprotection',\n",
-    "    'techsupport',\n",
-    "    'streamingtv',\n",
-    "    'streamingmovies',\n",
-    "    'contract',\n",
-    "    'paperlessbilling',\n",
-    "    'paymentmethod',\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "gender              2\n",
-       "seniorcitizen       2\n",
-       "partner             2\n",
-       "dependents          2\n",
-       "phoneservice        2\n",
-       "multiplelines       3\n",
-       "internetservice     3\n",
-       "onlinesecurity      3\n",
-       "onlinebackup        3\n",
-       "deviceprotection    3\n",
-       "techsupport         3\n",
-       "streamingtv         3\n",
-       "streamingmovies     3\n",
-       "contract            3\n",
-       "paperlessbilling    2\n",
-       "paymentmethod       4\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_full_train[categorical].nunique()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.5 Feature importance: Churn rate and risk ratio\n",
-    "\n",
-    "Feature importance analysis (part of EDA) - identifying which features affect our target variable\n",
-    "\n",
-    "* Churn rate\n",
-    "* Risk ratio\n",
-    "* Mutual information - later"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Churn rate"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>customerid</th>\n",
-       "      <th>gender</th>\n",
-       "      <th>seniorcitizen</th>\n",
-       "      <th>partner</th>\n",
-       "      <th>dependents</th>\n",
-       "      <th>tenure</th>\n",
-       "      <th>phoneservice</th>\n",
-       "      <th>multiplelines</th>\n",
-       "      <th>internetservice</th>\n",
-       "      <th>onlinesecurity</th>\n",
-       "      <th>...</th>\n",
-       "      <th>deviceprotection</th>\n",
-       "      <th>techsupport</th>\n",
-       "      <th>streamingtv</th>\n",
-       "      <th>streamingmovies</th>\n",
-       "      <th>contract</th>\n",
-       "      <th>paperlessbilling</th>\n",
-       "      <th>paymentmethod</th>\n",
-       "      <th>monthlycharges</th>\n",
-       "      <th>totalcharges</th>\n",
-       "      <th>churn</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>5442-pptjy</td>\n",
-       "      <td>male</td>\n",
-       "      <td>0</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>12</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no_internet_service</td>\n",
-       "      <td>...</td>\n",
-       "      <td>no_internet_service</td>\n",
-       "      <td>no_internet_service</td>\n",
-       "      <td>no_internet_service</td>\n",
-       "      <td>no_internet_service</td>\n",
-       "      <td>two_year</td>\n",
-       "      <td>no</td>\n",
-       "      <td>mailed_check</td>\n",
-       "      <td>19.70</td>\n",
-       "      <td>258.35</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>6261-rcvns</td>\n",
-       "      <td>female</td>\n",
-       "      <td>0</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>42</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "      <td>dsl</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>...</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>one_year</td>\n",
-       "      <td>no</td>\n",
-       "      <td>credit_card_(automatic)</td>\n",
-       "      <td>73.90</td>\n",
-       "      <td>3160.55</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2176-osjuv</td>\n",
-       "      <td>male</td>\n",
-       "      <td>0</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "      <td>71</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>dsl</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>...</td>\n",
-       "      <td>no</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>two_year</td>\n",
-       "      <td>no</td>\n",
-       "      <td>bank_transfer_(automatic)</td>\n",
-       "      <td>65.15</td>\n",
-       "      <td>4681.75</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>6161-erdgd</td>\n",
-       "      <td>male</td>\n",
-       "      <td>0</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>71</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>dsl</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>...</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>one_year</td>\n",
-       "      <td>no</td>\n",
-       "      <td>electronic_check</td>\n",
-       "      <td>85.45</td>\n",
-       "      <td>6300.85</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>2364-ufrom</td>\n",
-       "      <td>male</td>\n",
-       "      <td>0</td>\n",
-       "      <td>no</td>\n",
-       "      <td>no</td>\n",
-       "      <td>30</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "      <td>dsl</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>...</td>\n",
-       "      <td>no</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>yes</td>\n",
-       "      <td>no</td>\n",
-       "      <td>one_year</td>\n",
-       "      <td>no</td>\n",
-       "      <td>electronic_check</td>\n",
-       "      <td>70.40</td>\n",
-       "      <td>2044.75</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>5 rows × 21 columns</p>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "AZMgWwpmF5zn"
+      },
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "import numpy as np\n",
+        "\n",
+        "import matplotlib.pyplot as plt"
       ],
-      "text/plain": [
-       "   customerid  gender  seniorcitizen partner dependents  tenure phoneservice  \\\n",
-       "0  5442-pptjy    male              0     yes        yes      12          yes   \n",
-       "1  6261-rcvns  female              0      no         no      42          yes   \n",
-       "2  2176-osjuv    male              0     yes         no      71          yes   \n",
-       "3  6161-erdgd    male              0     yes        yes      71          yes   \n",
-       "4  2364-ufrom    male              0      no         no      30          yes   \n",
-       "\n",
-       "  multiplelines internetservice       onlinesecurity  ...  \\\n",
-       "0            no              no  no_internet_service  ...   \n",
-       "1            no             dsl                  yes  ...   \n",
-       "2           yes             dsl                  yes  ...   \n",
-       "3           yes             dsl                  yes  ...   \n",
-       "4            no             dsl                  yes  ...   \n",
-       "\n",
-       "      deviceprotection          techsupport          streamingtv  \\\n",
-       "0  no_internet_service  no_internet_service  no_internet_service   \n",
-       "1                  yes                  yes                   no   \n",
-       "2                   no                  yes                   no   \n",
-       "3                  yes                  yes                  yes   \n",
-       "4                   no                  yes                  yes   \n",
-       "\n",
-       "       streamingmovies  contract paperlessbilling              paymentmethod  \\\n",
-       "0  no_internet_service  two_year               no               mailed_check   \n",
-       "1                  yes  one_year               no    credit_card_(automatic)   \n",
-       "2                   no  two_year               no  bank_transfer_(automatic)   \n",
-       "3                  yes  one_year               no           electronic_check   \n",
-       "4                   no  one_year               no           electronic_check   \n",
-       "\n",
-       "  monthlycharges  totalcharges  churn  \n",
-       "0          19.70        258.35      0  \n",
-       "1          73.90       3160.55      1  \n",
-       "2          65.15       4681.75      0  \n",
-       "3          85.45       6300.85      0  \n",
-       "4          70.40       2044.75      0  \n",
-       "\n",
-       "[5 rows x 21 columns]"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_full_train.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.27682403433476394"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "churn_female = df_full_train[df_full_train.gender == 'female'].churn.mean()\n",
-    "churn_female"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.2632135306553911"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "churn_male = df_full_train[df_full_train.gender == 'male'].churn.mean()\n",
-    "churn_male"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.26996805111821087"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "global_churn = df_full_train.churn.mean()\n",
-    "global_churn"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "-0.006855983216553063"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "global_churn - churn_female"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.006754520462819769"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "global_churn - churn_male"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "no     2932\n",
-       "yes    2702\n",
-       "Name: partner, dtype: int64"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_full_train.partner.value_counts()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.20503330866025166"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "churn_partner = df_full_train[df_full_train.partner == 'yes'].churn.mean()\n",
-    "churn_partner"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.06493474245795922"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "global_churn - churn_partner"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.3298090040927694"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "churn_no_partner = df_full_train[df_full_train.partner == 'no'].churn.mean()\n",
-    "churn_no_partner"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "-0.05984095297455855"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "global_churn - churn_no_partner"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Risk ratio"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1.2216593879412643"
-      ]
-     },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "churn_no_partner / global_churn"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.7594724924338315"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "churn_partner / global_churn"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```\n",
-    "SELECT\n",
-    "    gender,\n",
-    "    AVG(churn),\n",
-    "    AVG(churn) - global_churn AS diff,\n",
-    "    AVG(churn) / global_churn AS risk\n",
-    "FROM\n",
-    "    data\n",
-    "GROUP BY\n",
-    "    gender;\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import display"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "gender\n"
-     ]
+      "id": "AZMgWwpmF5zn"
     },
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>gender</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>female</th>\n",
-       "      <td>0.276824</td>\n",
-       "      <td>2796</td>\n",
-       "      <td>0.006856</td>\n",
-       "      <td>1.025396</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>male</th>\n",
-       "      <td>0.263214</td>\n",
-       "      <td>2838</td>\n",
-       "      <td>-0.006755</td>\n",
-       "      <td>0.974980</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "GwFaUQTxF5zo"
+      },
+      "outputs": [],
+      "source": [
+        "data = 'https://raw.githubusercontent.com/alexeygrigorev/mlbookcamp-code/master/chapter-03-churn-prediction/WA_Fn-UseC_-Telco-Customer-Churn.csv'"
       ],
-      "text/plain": [
-       "            mean  count      diff      risk\n",
-       "gender                                     \n",
-       "female  0.276824   2796  0.006856  1.025396\n",
-       "male    0.263214   2838 -0.006755  0.974980"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+      "id": "GwFaUQTxF5zo"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "seniorcitizen\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>seniorcitizen</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0.242270</td>\n",
-       "      <td>4722</td>\n",
-       "      <td>-0.027698</td>\n",
-       "      <td>0.897403</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0.413377</td>\n",
-       "      <td>912</td>\n",
-       "      <td>0.143409</td>\n",
-       "      <td>1.531208</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "738o7jkPF5zp",
+        "outputId": "c2dc3087-a165-453b-8ab0-1a6b6f94219e"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "--2021-09-17 21:42:33--  https://raw.githubusercontent.com/alexeygrigorev/mlbookcamp-code/master/chapter-03-churn-prediction/WA_Fn-UseC_-Telco-Customer-Churn.csv\n",
+            "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.109.133, 185.199.110.133, 185.199.108.133, ...\n",
+            "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.109.133|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: 977501 (955K) [text/plain]\n",
+            "Saving to: ‘data-week-3.csv’\n",
+            "\n",
+            "data-week-3.csv     100%[===================>] 954,59K  --.-KB/s    in 0,1s    \n",
+            "\n",
+            "2021-09-17 21:42:33 (8,64 MB/s) - ‘data-week-3.csv’ saved [977501/977501]\n",
+            "\n"
+          ]
+        }
       ],
-      "text/plain": [
-       "                   mean  count      diff      risk\n",
-       "seniorcitizen                                     \n",
-       "0              0.242270   4722 -0.027698  0.897403\n",
-       "1              0.413377    912  0.143409  1.531208"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "partner\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>partner</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>no</th>\n",
-       "      <td>0.329809</td>\n",
-       "      <td>2932</td>\n",
-       "      <td>0.059841</td>\n",
-       "      <td>1.221659</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>yes</th>\n",
-       "      <td>0.205033</td>\n",
-       "      <td>2702</td>\n",
-       "      <td>-0.064935</td>\n",
-       "      <td>0.759472</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "source": [
+        "!wget $data -O data-week-3.csv"
       ],
-      "text/plain": [
-       "             mean  count      diff      risk\n",
-       "partner                                     \n",
-       "no       0.329809   2932  0.059841  1.221659\n",
-       "yes      0.205033   2702 -0.064935  0.759472"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+      "id": "738o7jkPF5zp"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "dependents\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>dependents</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>no</th>\n",
-       "      <td>0.313760</td>\n",
-       "      <td>3968</td>\n",
-       "      <td>0.043792</td>\n",
-       "      <td>1.162212</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>yes</th>\n",
-       "      <td>0.165666</td>\n",
-       "      <td>1666</td>\n",
-       "      <td>-0.104302</td>\n",
-       "      <td>0.613651</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "D4WQSjH5F5zq",
+        "outputId": "ab3318c8-f878-4e63-9080-c19ebaca5df7"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>customerID</th>\n",
+              "      <th>gender</th>\n",
+              "      <th>SeniorCitizen</th>\n",
+              "      <th>Partner</th>\n",
+              "      <th>Dependents</th>\n",
+              "      <th>tenure</th>\n",
+              "      <th>PhoneService</th>\n",
+              "      <th>MultipleLines</th>\n",
+              "      <th>InternetService</th>\n",
+              "      <th>OnlineSecurity</th>\n",
+              "      <th>...</th>\n",
+              "      <th>DeviceProtection</th>\n",
+              "      <th>TechSupport</th>\n",
+              "      <th>StreamingTV</th>\n",
+              "      <th>StreamingMovies</th>\n",
+              "      <th>Contract</th>\n",
+              "      <th>PaperlessBilling</th>\n",
+              "      <th>PaymentMethod</th>\n",
+              "      <th>MonthlyCharges</th>\n",
+              "      <th>TotalCharges</th>\n",
+              "      <th>Churn</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>7590-VHVEG</td>\n",
+              "      <td>Female</td>\n",
+              "      <td>0</td>\n",
+              "      <td>Yes</td>\n",
+              "      <td>No</td>\n",
+              "      <td>1</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No phone service</td>\n",
+              "      <td>DSL</td>\n",
+              "      <td>No</td>\n",
+              "      <td>...</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>Month-to-month</td>\n",
+              "      <td>Yes</td>\n",
+              "      <td>Electronic check</td>\n",
+              "      <td>29.85</td>\n",
+              "      <td>29.85</td>\n",
+              "      <td>No</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>5575-GNVDE</td>\n",
+              "      <td>Male</td>\n",
+              "      <td>0</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>34</td>\n",
+              "      <td>Yes</td>\n",
+              "      <td>No</td>\n",
+              "      <td>DSL</td>\n",
+              "      <td>Yes</td>\n",
+              "      <td>...</td>\n",
+              "      <td>Yes</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>One year</td>\n",
+              "      <td>No</td>\n",
+              "      <td>Mailed check</td>\n",
+              "      <td>56.95</td>\n",
+              "      <td>1889.5</td>\n",
+              "      <td>No</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>3668-QPYBK</td>\n",
+              "      <td>Male</td>\n",
+              "      <td>0</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>2</td>\n",
+              "      <td>Yes</td>\n",
+              "      <td>No</td>\n",
+              "      <td>DSL</td>\n",
+              "      <td>Yes</td>\n",
+              "      <td>...</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>Month-to-month</td>\n",
+              "      <td>Yes</td>\n",
+              "      <td>Mailed check</td>\n",
+              "      <td>53.85</td>\n",
+              "      <td>108.15</td>\n",
+              "      <td>Yes</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>7795-CFOCW</td>\n",
+              "      <td>Male</td>\n",
+              "      <td>0</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>45</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No phone service</td>\n",
+              "      <td>DSL</td>\n",
+              "      <td>Yes</td>\n",
+              "      <td>...</td>\n",
+              "      <td>Yes</td>\n",
+              "      <td>Yes</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>One year</td>\n",
+              "      <td>No</td>\n",
+              "      <td>Bank transfer (automatic)</td>\n",
+              "      <td>42.30</td>\n",
+              "      <td>1840.75</td>\n",
+              "      <td>No</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>9237-HQITU</td>\n",
+              "      <td>Female</td>\n",
+              "      <td>0</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>2</td>\n",
+              "      <td>Yes</td>\n",
+              "      <td>No</td>\n",
+              "      <td>Fiber optic</td>\n",
+              "      <td>No</td>\n",
+              "      <td>...</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>No</td>\n",
+              "      <td>Month-to-month</td>\n",
+              "      <td>Yes</td>\n",
+              "      <td>Electronic check</td>\n",
+              "      <td>70.70</td>\n",
+              "      <td>151.65</td>\n",
+              "      <td>Yes</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>5 rows × 21 columns</p>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   customerID  gender  SeniorCitizen Partner Dependents  tenure PhoneService  \\\n",
+              "0  7590-VHVEG  Female              0     Yes         No       1           No   \n",
+              "1  5575-GNVDE    Male              0      No         No      34          Yes   \n",
+              "2  3668-QPYBK    Male              0      No         No       2          Yes   \n",
+              "3  7795-CFOCW    Male              0      No         No      45           No   \n",
+              "4  9237-HQITU  Female              0      No         No       2          Yes   \n",
+              "\n",
+              "      MultipleLines InternetService OnlineSecurity  ... DeviceProtection  \\\n",
+              "0  No phone service             DSL             No  ...               No   \n",
+              "1                No             DSL            Yes  ...              Yes   \n",
+              "2                No             DSL            Yes  ...               No   \n",
+              "3  No phone service             DSL            Yes  ...              Yes   \n",
+              "4                No     Fiber optic             No  ...               No   \n",
+              "\n",
+              "  TechSupport StreamingTV StreamingMovies        Contract PaperlessBilling  \\\n",
+              "0          No          No              No  Month-to-month              Yes   \n",
+              "1          No          No              No        One year               No   \n",
+              "2          No          No              No  Month-to-month              Yes   \n",
+              "3         Yes          No              No        One year               No   \n",
+              "4          No          No              No  Month-to-month              Yes   \n",
+              "\n",
+              "               PaymentMethod MonthlyCharges  TotalCharges Churn  \n",
+              "0           Electronic check          29.85         29.85    No  \n",
+              "1               Mailed check          56.95        1889.5    No  \n",
+              "2               Mailed check          53.85        108.15   Yes  \n",
+              "3  Bank transfer (automatic)          42.30       1840.75    No  \n",
+              "4           Electronic check          70.70        151.65   Yes  \n",
+              "\n",
+              "[5 rows x 21 columns]"
+            ]
+          },
+          "execution_count": 4,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
       ],
-      "text/plain": [
-       "                mean  count      diff      risk\n",
-       "dependents                                     \n",
-       "no          0.313760   3968  0.043792  1.162212\n",
-       "yes         0.165666   1666 -0.104302  0.613651"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "phoneservice\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>phoneservice</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>no</th>\n",
-       "      <td>0.241316</td>\n",
-       "      <td>547</td>\n",
-       "      <td>-0.028652</td>\n",
-       "      <td>0.893870</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>yes</th>\n",
-       "      <td>0.273049</td>\n",
-       "      <td>5087</td>\n",
-       "      <td>0.003081</td>\n",
-       "      <td>1.011412</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "source": [
+        "df = pd.read_csv('data-week-3.csv')\n",
+        "df.head()"
       ],
-      "text/plain": [
-       "                  mean  count      diff      risk\n",
-       "phoneservice                                     \n",
-       "no            0.241316    547 -0.028652  0.893870\n",
-       "yes           0.273049   5087  0.003081  1.011412"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+      "id": "D4WQSjH5F5zq"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "multiplelines\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>multiplelines</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>no</th>\n",
-       "      <td>0.257407</td>\n",
-       "      <td>2700</td>\n",
-       "      <td>-0.012561</td>\n",
-       "      <td>0.953474</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>no_phone_service</th>\n",
-       "      <td>0.241316</td>\n",
-       "      <td>547</td>\n",
-       "      <td>-0.028652</td>\n",
-       "      <td>0.893870</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>yes</th>\n",
-       "      <td>0.290742</td>\n",
-       "      <td>2387</td>\n",
-       "      <td>0.020773</td>\n",
-       "      <td>1.076948</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "tvMc9_nNF5zq"
+      },
+      "outputs": [],
+      "source": [
+        "df.columns = df.columns.str.lower().str.replace(' ', '_')\n",
+        "\n",
+        "categorical_columns = list(df.dtypes[df.dtypes == 'object'].index)\n",
+        "\n",
+        "for c in categorical_columns:\n",
+        "    df[c] = df[c].str.lower().str.replace(' ', '_')"
       ],
-      "text/plain": [
-       "                      mean  count      diff      risk\n",
-       "multiplelines                                        \n",
-       "no                0.257407   2700 -0.012561  0.953474\n",
-       "no_phone_service  0.241316    547 -0.028652  0.893870\n",
-       "yes               0.290742   2387  0.020773  1.076948"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+      "id": "tvMc9_nNF5zq"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "internetservice\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>internetservice</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>dsl</th>\n",
-       "      <td>0.192347</td>\n",
-       "      <td>1934</td>\n",
-       "      <td>-0.077621</td>\n",
-       "      <td>0.712482</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>fiber_optic</th>\n",
-       "      <td>0.425171</td>\n",
-       "      <td>2479</td>\n",
-       "      <td>0.155203</td>\n",
-       "      <td>1.574895</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>no</th>\n",
-       "      <td>0.077805</td>\n",
-       "      <td>1221</td>\n",
-       "      <td>-0.192163</td>\n",
-       "      <td>0.288201</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6-MRdCe0F5zr",
+        "outputId": "e1ff6122-d76e-4575-ab4d-b63aade27fa8"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>0</th>\n",
+              "      <th>1</th>\n",
+              "      <th>2</th>\n",
+              "      <th>3</th>\n",
+              "      <th>4</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>customerid</th>\n",
+              "      <td>7590-vhveg</td>\n",
+              "      <td>5575-gnvde</td>\n",
+              "      <td>3668-qpybk</td>\n",
+              "      <td>7795-cfocw</td>\n",
+              "      <td>9237-hqitu</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>gender</th>\n",
+              "      <td>female</td>\n",
+              "      <td>male</td>\n",
+              "      <td>male</td>\n",
+              "      <td>male</td>\n",
+              "      <td>female</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>seniorcitizen</th>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>partner</th>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>dependents</th>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>tenure</th>\n",
+              "      <td>1</td>\n",
+              "      <td>34</td>\n",
+              "      <td>2</td>\n",
+              "      <td>45</td>\n",
+              "      <td>2</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>phoneservice</th>\n",
+              "      <td>no</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "      <td>yes</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>multiplelines</th>\n",
+              "      <td>no_phone_service</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no_phone_service</td>\n",
+              "      <td>no</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>internetservice</th>\n",
+              "      <td>dsl</td>\n",
+              "      <td>dsl</td>\n",
+              "      <td>dsl</td>\n",
+              "      <td>dsl</td>\n",
+              "      <td>fiber_optic</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>onlinesecurity</th>\n",
+              "      <td>no</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>onlinebackup</th>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>deviceprotection</th>\n",
+              "      <td>no</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>techsupport</th>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>streamingtv</th>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>streamingmovies</th>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>contract</th>\n",
+              "      <td>month-to-month</td>\n",
+              "      <td>one_year</td>\n",
+              "      <td>month-to-month</td>\n",
+              "      <td>one_year</td>\n",
+              "      <td>month-to-month</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>paperlessbilling</th>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "      <td>yes</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>paymentmethod</th>\n",
+              "      <td>electronic_check</td>\n",
+              "      <td>mailed_check</td>\n",
+              "      <td>mailed_check</td>\n",
+              "      <td>bank_transfer_(automatic)</td>\n",
+              "      <td>electronic_check</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>monthlycharges</th>\n",
+              "      <td>29.85</td>\n",
+              "      <td>56.95</td>\n",
+              "      <td>53.85</td>\n",
+              "      <td>42.3</td>\n",
+              "      <td>70.7</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>totalcharges</th>\n",
+              "      <td>29.85</td>\n",
+              "      <td>1889.5</td>\n",
+              "      <td>108.15</td>\n",
+              "      <td>1840.75</td>\n",
+              "      <td>151.65</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>churn</th>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "      <td>yes</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                                 0             1               2  \\\n",
+              "customerid              7590-vhveg    5575-gnvde      3668-qpybk   \n",
+              "gender                      female          male            male   \n",
+              "seniorcitizen                    0             0               0   \n",
+              "partner                        yes            no              no   \n",
+              "dependents                      no            no              no   \n",
+              "tenure                           1            34               2   \n",
+              "phoneservice                    no           yes             yes   \n",
+              "multiplelines     no_phone_service            no              no   \n",
+              "internetservice                dsl           dsl             dsl   \n",
+              "onlinesecurity                  no           yes             yes   \n",
+              "onlinebackup                   yes            no             yes   \n",
+              "deviceprotection                no           yes              no   \n",
+              "techsupport                     no            no              no   \n",
+              "streamingtv                     no            no              no   \n",
+              "streamingmovies                 no            no              no   \n",
+              "contract            month-to-month      one_year  month-to-month   \n",
+              "paperlessbilling               yes            no             yes   \n",
+              "paymentmethod     electronic_check  mailed_check    mailed_check   \n",
+              "monthlycharges               29.85         56.95           53.85   \n",
+              "totalcharges                 29.85        1889.5          108.15   \n",
+              "churn                           no            no             yes   \n",
+              "\n",
+              "                                          3                 4  \n",
+              "customerid                       7795-cfocw        9237-hqitu  \n",
+              "gender                                 male            female  \n",
+              "seniorcitizen                             0                 0  \n",
+              "partner                                  no                no  \n",
+              "dependents                               no                no  \n",
+              "tenure                                   45                 2  \n",
+              "phoneservice                             no               yes  \n",
+              "multiplelines              no_phone_service                no  \n",
+              "internetservice                         dsl       fiber_optic  \n",
+              "onlinesecurity                          yes                no  \n",
+              "onlinebackup                             no                no  \n",
+              "deviceprotection                        yes                no  \n",
+              "techsupport                             yes                no  \n",
+              "streamingtv                              no                no  \n",
+              "streamingmovies                          no                no  \n",
+              "contract                           one_year    month-to-month  \n",
+              "paperlessbilling                         no               yes  \n",
+              "paymentmethod     bank_transfer_(automatic)  electronic_check  \n",
+              "monthlycharges                         42.3              70.7  \n",
+              "totalcharges                        1840.75            151.65  \n",
+              "churn                                    no               yes  "
+            ]
+          },
+          "execution_count": 6,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
       ],
-      "text/plain": [
-       "                     mean  count      diff      risk\n",
-       "internetservice                                     \n",
-       "dsl              0.192347   1934 -0.077621  0.712482\n",
-       "fiber_optic      0.425171   2479  0.155203  1.574895\n",
-       "no               0.077805   1221 -0.192163  0.288201"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "onlinesecurity\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>onlinesecurity</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>no</th>\n",
-       "      <td>0.420921</td>\n",
-       "      <td>2801</td>\n",
-       "      <td>0.150953</td>\n",
-       "      <td>1.559152</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>no_internet_service</th>\n",
-       "      <td>0.077805</td>\n",
-       "      <td>1221</td>\n",
-       "      <td>-0.192163</td>\n",
-       "      <td>0.288201</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>yes</th>\n",
-       "      <td>0.153226</td>\n",
-       "      <td>1612</td>\n",
-       "      <td>-0.116742</td>\n",
-       "      <td>0.567570</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "source": [
+        "df.head().T"
       ],
-      "text/plain": [
-       "                         mean  count      diff      risk\n",
-       "onlinesecurity                                          \n",
-       "no                   0.420921   2801  0.150953  1.559152\n",
-       "no_internet_service  0.077805   1221 -0.192163  0.288201\n",
-       "yes                  0.153226   1612 -0.116742  0.567570"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+      "id": "6-MRdCe0F5zr"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "onlinebackup\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>onlinebackup</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>no</th>\n",
-       "      <td>0.404323</td>\n",
-       "      <td>2498</td>\n",
-       "      <td>0.134355</td>\n",
-       "      <td>1.497672</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>no_internet_service</th>\n",
-       "      <td>0.077805</td>\n",
-       "      <td>1221</td>\n",
-       "      <td>-0.192163</td>\n",
-       "      <td>0.288201</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>yes</th>\n",
-       "      <td>0.217232</td>\n",
-       "      <td>1915</td>\n",
-       "      <td>-0.052736</td>\n",
-       "      <td>0.804660</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "PbXP2ZJyF5zr"
+      },
+      "outputs": [],
+      "source": [
+        "tc = pd.to_numeric(df.totalcharges, errors='coerce')"
       ],
-      "text/plain": [
-       "                         mean  count      diff      risk\n",
-       "onlinebackup                                            \n",
-       "no                   0.404323   2498  0.134355  1.497672\n",
-       "no_internet_service  0.077805   1221 -0.192163  0.288201\n",
-       "yes                  0.217232   1915 -0.052736  0.804660"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+      "id": "PbXP2ZJyF5zr"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "deviceprotection\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>deviceprotection</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>no</th>\n",
-       "      <td>0.395875</td>\n",
-       "      <td>2473</td>\n",
-       "      <td>0.125907</td>\n",
-       "      <td>1.466379</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>no_internet_service</th>\n",
-       "      <td>0.077805</td>\n",
-       "      <td>1221</td>\n",
-       "      <td>-0.192163</td>\n",
-       "      <td>0.288201</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>yes</th>\n",
-       "      <td>0.230412</td>\n",
-       "      <td>1940</td>\n",
-       "      <td>-0.039556</td>\n",
-       "      <td>0.853480</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "W6JJ5kGxF5zs"
+      },
+      "outputs": [],
+      "source": [
+        "df.totalcharges = pd.to_numeric(df.totalcharges, errors='coerce')"
       ],
-      "text/plain": [
-       "                         mean  count      diff      risk\n",
-       "deviceprotection                                        \n",
-       "no                   0.395875   2473  0.125907  1.466379\n",
-       "no_internet_service  0.077805   1221 -0.192163  0.288201\n",
-       "yes                  0.230412   1940 -0.039556  0.853480"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+      "id": "W6JJ5kGxF5zs"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "techsupport\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>techsupport</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>no</th>\n",
-       "      <td>0.418914</td>\n",
-       "      <td>2781</td>\n",
-       "      <td>0.148946</td>\n",
-       "      <td>1.551717</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>no_internet_service</th>\n",
-       "      <td>0.077805</td>\n",
-       "      <td>1221</td>\n",
-       "      <td>-0.192163</td>\n",
-       "      <td>0.288201</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>yes</th>\n",
-       "      <td>0.159926</td>\n",
-       "      <td>1632</td>\n",
-       "      <td>-0.110042</td>\n",
-       "      <td>0.592390</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3bmRoJ_KF5zs"
+      },
+      "outputs": [],
+      "source": [
+        "df.totalcharges = df.totalcharges.fillna(0)"
       ],
-      "text/plain": [
-       "                         mean  count      diff      risk\n",
-       "techsupport                                             \n",
-       "no                   0.418914   2781  0.148946  1.551717\n",
-       "no_internet_service  0.077805   1221 -0.192163  0.288201\n",
-       "yes                  0.159926   1632 -0.110042  0.592390"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+      "id": "3bmRoJ_KF5zs"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "streamingtv\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>streamingtv</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>no</th>\n",
-       "      <td>0.342832</td>\n",
-       "      <td>2246</td>\n",
-       "      <td>0.072864</td>\n",
-       "      <td>1.269897</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>no_internet_service</th>\n",
-       "      <td>0.077805</td>\n",
-       "      <td>1221</td>\n",
-       "      <td>-0.192163</td>\n",
-       "      <td>0.288201</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>yes</th>\n",
-       "      <td>0.302723</td>\n",
-       "      <td>2167</td>\n",
-       "      <td>0.032755</td>\n",
-       "      <td>1.121328</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "q1ckN6sPF5zs",
+        "outputId": "04d9e85e-9c34-48b3-dbcc-124a3cc7a30b"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0     no\n",
+              "1     no\n",
+              "2    yes\n",
+              "3     no\n",
+              "4    yes\n",
+              "Name: churn, dtype: object"
+            ]
+          },
+          "execution_count": 10,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
       ],
-      "text/plain": [
-       "                         mean  count      diff      risk\n",
-       "streamingtv                                             \n",
-       "no                   0.342832   2246  0.072864  1.269897\n",
-       "no_internet_service  0.077805   1221 -0.192163  0.288201\n",
-       "yes                  0.302723   2167  0.032755  1.121328"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "streamingmovies\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>streamingmovies</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>no</th>\n",
-       "      <td>0.338906</td>\n",
-       "      <td>2213</td>\n",
-       "      <td>0.068938</td>\n",
-       "      <td>1.255358</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>no_internet_service</th>\n",
-       "      <td>0.077805</td>\n",
-       "      <td>1221</td>\n",
-       "      <td>-0.192163</td>\n",
-       "      <td>0.288201</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>yes</th>\n",
-       "      <td>0.307273</td>\n",
-       "      <td>2200</td>\n",
-       "      <td>0.037305</td>\n",
-       "      <td>1.138182</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "source": [
+        "df.churn.head()"
       ],
-      "text/plain": [
-       "                         mean  count      diff      risk\n",
-       "streamingmovies                                         \n",
-       "no                   0.338906   2213  0.068938  1.255358\n",
-       "no_internet_service  0.077805   1221 -0.192163  0.288201\n",
-       "yes                  0.307273   2200  0.037305  1.138182"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+      "id": "q1ckN6sPF5zs"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "contract\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>contract</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>month-to-month</th>\n",
-       "      <td>0.431701</td>\n",
-       "      <td>3104</td>\n",
-       "      <td>0.161733</td>\n",
-       "      <td>1.599082</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>one_year</th>\n",
-       "      <td>0.120573</td>\n",
-       "      <td>1186</td>\n",
-       "      <td>-0.149395</td>\n",
-       "      <td>0.446621</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>two_year</th>\n",
-       "      <td>0.028274</td>\n",
-       "      <td>1344</td>\n",
-       "      <td>-0.241694</td>\n",
-       "      <td>0.104730</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "0XNww-A-F5zt"
+      },
+      "outputs": [],
+      "source": [
+        "df.churn = (df.churn == 'yes').astype(int)"
       ],
-      "text/plain": [
-       "                    mean  count      diff      risk\n",
-       "contract                                           \n",
-       "month-to-month  0.431701   3104  0.161733  1.599082\n",
-       "one_year        0.120573   1186 -0.149395  0.446621\n",
-       "two_year        0.028274   1344 -0.241694  0.104730"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+      "id": "0XNww-A-F5zt"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "paperlessbilling\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>paperlessbilling</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>no</th>\n",
-       "      <td>0.172071</td>\n",
-       "      <td>2313</td>\n",
-       "      <td>-0.097897</td>\n",
-       "      <td>0.637375</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>yes</th>\n",
-       "      <td>0.338151</td>\n",
-       "      <td>3321</td>\n",
-       "      <td>0.068183</td>\n",
-       "      <td>1.252560</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PN6XW2DgF5zt"
+      },
+      "source": [
+        "## 3.3 Setting up the validation framework\n",
+        "\n",
+        "* Perform the train/validation/test split with Scikit-Learn"
       ],
-      "text/plain": [
-       "                      mean  count      diff      risk\n",
-       "paperlessbilling                                     \n",
-       "no                0.172071   2313 -0.097897  0.637375\n",
-       "yes               0.338151   3321  0.068183  1.252560"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+      "id": "PN6XW2DgF5zt"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "paymentmethod\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>count</th>\n",
-       "      <th>diff</th>\n",
-       "      <th>risk</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>paymentmethod</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>bank_transfer_(automatic)</th>\n",
-       "      <td>0.168171</td>\n",
-       "      <td>1219</td>\n",
-       "      <td>-0.101797</td>\n",
-       "      <td>0.622928</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>credit_card_(automatic)</th>\n",
-       "      <td>0.164339</td>\n",
-       "      <td>1217</td>\n",
-       "      <td>-0.105630</td>\n",
-       "      <td>0.608733</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>electronic_check</th>\n",
-       "      <td>0.455890</td>\n",
-       "      <td>1893</td>\n",
-       "      <td>0.185922</td>\n",
-       "      <td>1.688682</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>mailed_check</th>\n",
-       "      <td>0.193870</td>\n",
-       "      <td>1305</td>\n",
-       "      <td>-0.076098</td>\n",
-       "      <td>0.718121</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3QtlS746F5zu"
+      },
+      "outputs": [],
+      "source": [
+        "from sklearn.model_selection import train_test_split"
       ],
-      "text/plain": [
-       "                               mean  count      diff      risk\n",
-       "paymentmethod                                                 \n",
-       "bank_transfer_(automatic)  0.168171   1219 -0.101797  0.622928\n",
-       "credit_card_(automatic)    0.164339   1217 -0.105630  0.608733\n",
-       "electronic_check           0.455890   1893  0.185922  1.688682\n",
-       "mailed_check               0.193870   1305 -0.076098  0.718121"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+      "id": "3QtlS746F5zu"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "for c in categorical:\n",
-    "    print(c)\n",
-    "    df_group = df_full_train.groupby(c).churn.agg(['mean', 'count'])\n",
-    "    df_group['diff'] = df_group['mean'] - global_churn\n",
-    "    df_group['risk'] = df_group['mean'] / global_churn\n",
-    "    display(df_group)\n",
-    "    print()\n",
-    "    print()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.6 Feature importance: Mutual information\n",
-    "\n",
-    "Mutual information - concept from information theory, it tells us how much \n",
-    "we can learn about one variable if we know the value of another\n",
-    "\n",
-    "* https://en.wikipedia.org/wiki/Mutual_information"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.metrics import mutual_info_score"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0983203874041556"
-      ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "mutual_info_score(df_full_train.churn, df_full_train.contract)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 41,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0001174846211139946"
-      ]
-     },
-     "execution_count": 41,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "mutual_info_score(df_full_train.gender, df_full_train.churn)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 42,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0983203874041556"
-      ]
-     },
-     "execution_count": 42,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "mutual_info_score(df_full_train.contract, df_full_train.churn)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 43,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.009967689095399745"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "mutual_info_score(df_full_train.partner, df_full_train.churn)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def mutual_info_churn_score(series):\n",
-    "    return mutual_info_score(series, df_full_train.churn)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 45,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "contract            0.098320\n",
-       "onlinesecurity      0.063085\n",
-       "techsupport         0.061032\n",
-       "internetservice     0.055868\n",
-       "onlinebackup        0.046923\n",
-       "deviceprotection    0.043453\n",
-       "paymentmethod       0.043210\n",
-       "streamingtv         0.031853\n",
-       "streamingmovies     0.031581\n",
-       "paperlessbilling    0.017589\n",
-       "dependents          0.012346\n",
-       "partner             0.009968\n",
-       "seniorcitizen       0.009410\n",
-       "multiplelines       0.000857\n",
-       "phoneservice        0.000229\n",
-       "gender              0.000117\n",
-       "dtype: float64"
-      ]
-     },
-     "execution_count": 45,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "mi = df_full_train[categorical].apply(mutual_info_churn_score)\n",
-    "mi.sort_values(ascending=False)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.7 Feature importance: Correlation\n",
-    "\n",
-    "How about numerical columns?\n",
-    "\n",
-    "* Correlation coefficient - https://en.wikipedia.org/wiki/Pearson_correlation_coefficient"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 46,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "72"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_full_train.tenure.max()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 47,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "tenure            0.351885\n",
-       "monthlycharges    0.196805\n",
-       "totalcharges      0.196353\n",
-       "dtype: float64"
-      ]
-     },
-     "execution_count": 47,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_full_train[numerical].corrwith(df_full_train.churn).abs()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 48,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.5953420669577875"
-      ]
-     },
-     "execution_count": 48,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_full_train[df_full_train.tenure <= 2].churn.mean()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 49,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.3994413407821229"
-      ]
-     },
-     "execution_count": 49,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_full_train[(df_full_train.tenure > 2) & (df_full_train.tenure <= 12)].churn.mean()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 50,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.17634908339788277"
-      ]
-     },
-     "execution_count": 50,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_full_train[df_full_train.tenure > 12].churn.mean()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 51,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.08795411089866156"
-      ]
-     },
-     "execution_count": 51,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_full_train[df_full_train.monthlycharges <= 20].churn.mean()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 52,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.18340943683409436"
-      ]
-     },
-     "execution_count": 52,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_full_train[(df_full_train.monthlycharges > 20) & (df_full_train.monthlycharges <= 50)].churn.mean()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 53,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.32499341585462205"
-      ]
-     },
-     "execution_count": 53,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_full_train[df_full_train.monthlycharges > 50].churn.mean()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.8 One-hot encoding\n",
-    "\n",
-    "* Use Scikit-Learn to encode categorical features"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 54,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.feature_extraction import DictVectorizer"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 55,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dv = DictVectorizer(sparse=False)\n",
-    "\n",
-    "train_dict = df_train[categorical + numerical].to_dict(orient='records')\n",
-    "X_train = dv.fit_transform(train_dict)\n",
-    "\n",
-    "val_dict = df_val[categorical + numerical].to_dict(orient='records')\n",
-    "X_val = dv.transform(val_dict)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.9 Logistic regression\n",
-    "\n",
-    "* Binary classification\n",
-    "* Linear vs logistic regression"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 56,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def sigmoid(z):\n",
-    "    return 1 / (1 + np.exp(-z))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 57,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "z = np.linspace(-7, 7, 51)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 58,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1.0"
-      ]
-     },
-     "execution_count": 58,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sigmoid(10000)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 59,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x7f342d0bf080>]"
-      ]
-     },
-     "execution_count": 59,
-     "metadata": {},
-     "output_type": "execute_result"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "y1rNOYZOF5zu"
+      },
+      "outputs": [],
+      "source": [
+        "df_full_train, df_test = train_test_split(df, test_size=0.2, random_state=1)\n",
+        "df_train, df_val = train_test_split(df_full_train, test_size=0.25, random_state=1)"
+      ],
+      "id": "y1rNOYZOF5zu"
     },
     {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD4CAYAAAD8Zh1EAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAfs0lEQVR4nO3deXiV9Z3+8ffnnKwkJAESEQiQREBBpIqA1AUX1LpVO9qp0Naxaks7rR07OouOM9bpXO1Y21+ntuO04lqtVRmrlam41KUiIgoubLIlYQtbwhZIyHrO5/dHoo0QyFFOeM5yv67rXOc85zxJbiC5+eZ7nuf5mrsjIiLJLxR0ABERiQ8VuohIilChi4ikCBW6iEiKUKGLiKSIjKC+cHFxsZeVlQX15UVEktI777yz3d1LunstsEIvKytj0aJFQX15EZGkZGbrD/aaplxERFKECl1EJEWo0EVEUoQKXUQkRajQRURSRI+FbmYPmFmtmS07yOtmZr8ws0ozW2Jm4+MfU0REehLLCP0h4IJDvH4hMLLzNgP41eHHEhGRT6rH49Ddfa6ZlR1il8uAh73jOrwLzKzIzAa5+5Y4ZRQR6RXuTmskSmt7lJb2jvvW9ihtkShtEe+8j9IaidIecSLRjuciUac9+pftqHdsRzufizhEolGiDlHveL7r46mjB/KZoUVx//PE48SiIcDGLts1nc8dUOhmNoOOUTzDhg2Lw5cWkXTi7uxrjVDf1HbAbW9zOw3N7TS2ttPQ0k5j521fa4SmtghNrRGa27o87izvIBxVkJOwhW7dPNftqhnuPhOYCTBhwgStrCEiQEdR72hsZcvuZjbtbmLz7iZq97awo6GF7Q0tbG9o7Xjc2NpjCWdnhMjPziDvw1tWmPzsDIrzs8nNDHfcssJkZ4bIzgiTnREiOyNEVpf7zHCIjFCIrAz76HFm2MgIh8gIGRlhIyNkhEMd26FQx3bIjHCo4xYyOu//8nzIwKy7yoyPeBR6DTC0y3YpsDkOn1dEUkg06myub6K6rpHqugaqtzeydnsjNbs6Crxlv6LODBsD8rIp7pvFgLxsRg3sS3HfLPr1yaIwN5Oi3EwKczMp+PA+J5O87DAZ4fQ9eC8ehT4buN7MHgdOAeo1fy6S3prbIqzYsodlm+pZUlPP8s17qN7eQHPbX0o7PzuDipI8xgwu4LwxAxlcmMOgolyGFOUyqDCH/nlZvTqaTUU9FrqZPQacBRSbWQ3wfSATwN1/DcwBLgIqgX3ANb0VVkQS07Y9zcyv2s6Cqp0srtnNmtoGItGOWdV+fTIZO6SQzx4znIqSPCqK8zmmJI+Svtkq7DiL5SiX6T287sB34pZIRBLe7n2tLKjewRuVO5hftZ2qukYAivpk8pnSIs4dPZCxQwo5obSQwYU5Ku4jJLDL54pIctnR0MLzy7fy7JItLKjeQdShT1aYSeX9mTZxGJ89ZgBjBhUQCqm8g6JCF5GD2tXYygvLt/Ls0i3Mr9pBJOpUFOfxnbNHcOaoEsaVFpGVkb5vQiYaFbqIHODdDbt48I11PLd0C+1RZ/iAPnzrzAouPmEwowf11RRKglKhiwgAbZEozy3bygPz1vL+xt30zc7gbz5bxuXjh3D84AKVeBJQoYukuT3NbTzy5noeeXM9W/c0UzagD/9+6fFccXIp+dmqiGSify2RNNUWifLY2xv4+Utr2NnYyukjivnhX43l7GOP0hubSUqFLpJm3J2XV9Tyo+dWUF3XyOSK/tx60RhOKC0MOpocJhW6SBpZtqmeHz67gjerd1BRkse9fzOBc0cfpfnxFKFCF0kDzW0R7nhuJb95cx39+mTxg8uOZ/qkYWSm8XVPUpEKXSTFLd9cz/cef581tQ187dQybjx/FAU5mUHHkl6gQhdJUdGoc9+8an7ywir69cni4WsnMWVUSdCxpBep0EVS0Jb6Jm6atZj5VTv43PED+c/Lx9E/LyvoWNLLVOgiKeblFdu4cdZiWtuj3HH5CVw5caje9EwTKnSRFPLIgvV8/5lljBlcwC+nj6e8OC/oSHIEqdBFUoC789MXV3H3q1Wcc9xR/PeXT6JPln68043+xUWSXGt7lJufWsJT725i+qSh/MdlY9N6GbZ0pkIXSWINLe387W/f4fU127nxvFF895wRmi9PYyp0kSRVu6eZrz24kFXb9nLnF8fxpQlDe/4gSWkqdJEktKOhhWn3LmBrfTP3Xz2Bs449KuhIkgBU6CJJpqGlnWseWsimXU08ct0pTCrvH3QkSRAqdJEk0toe5VuPvMPyzXu456snq8zlY/RWuEiSiEadG2e9z7zK7dxx+QmcO2Zg0JEkwajQRZKAu/Pv/7ecPy7Zwi0XHsdf6w1Q6YYKXSQJ/PKVSn7z5npmTKngm2ceE3QcSVAqdJEE97u3NvCzP63miyeXcsuFxwUdRxKYCl0kgb23YRe3PbOMs48t4Y7LT9BJQ3JIKnSRBLV7XyvX/+49ji7M4edXnqTT+aVHOmxRJAFFo85NsxZTu7eZJ791KoV9tMKQ9Ez/5YskoHtfr+bllbXcetFoPjO0KOg4kiRU6CIJZtG6ndz5wiouOuForj61LOg4kkRU6CIJZGdjx7x5ab9c7rhinN4ElU8kpkI3swvMbJWZVZrZzd28PszMXjWz98xsiZldFP+oIqktGnX+/on32bmvlbu/PJ6CHM2byyfTY6GbWRi4G7gQGANMN7Mx++32r8Asdz8JmAb8T7yDiqS6X8+t4rXVddx2yRjGDikMOo4koVhG6JOASnevdvdW4HHgsv32caCg83EhsDl+EUVS36qte/nZi6u5eNwgvnLKsKDjSJKKpdCHABu7bNd0PtfV7cBXzawGmAN8t7tPZGYzzGyRmS2qq6v7FHFFUk8k6tz81BIKcjP5j8vGat5cPrVYCr277y7fb3s68JC7lwIXAY+Y2QGf291nuvsEd59QUlLyydOKpKDfLljPext2c9slY+iflxV0HElisRR6DdD10m6lHDilch0wC8Dd3wRygOJ4BBRJZZt3N3Hn8yuZMqqEy04cHHQcSXKxFPpCYKSZlZtZFh1ves7eb58NwFQAMxtNR6FrTkXkENydf/vDMqIOP/yCplrk8PVY6O7eDlwPvACsoONoluVm9gMzu7Rzt5uAb5jZYuAx4Gvuvv+0jIh08ezSLby8spabzh/F0P59go4jKSCma7m4+xw63uzs+txtXR5/AJwW32giqWv3vlZun72ccaWFXHNaedBxJEXo4lwiAfjRnBXs2tfGw9eeQjikqRaJD536L3KEza/azqxFNXzjjArGDC7o+QNEYqRCFzmCWtuj3Pr0MoYP6MP3zh0ZdBxJMZpyETmCfrtgPWu3N/LgNRPJyQwHHUdSjEboIkdIfVMbv3hlDWeMLOasUTqxTuJPhS5yhPzPq5XUN7Vxy4Wjdcy59AoVusgRsHHnPh58Yx1XjC/VG6HSa1ToIkfAT19cRSgEN50/KugoksJU6CK9bPHG3Tzz/ma+fnoFgwpzg44jKUyFLtKL3J0fzllBcX4W3zrrmKDjSIpToYv0oj99sI231+7ke+eOIj9bRwlL71Khi/SStkiUO55fyTEleUybOLTnDxA5TCp0kV7y+NsbqK5r5JYLR5MR1o+a9D59l4n0gsaWdn7+0homV/Rn6uijgo4jaUKTeiK94JEF69nR2Mq9Fxynk4jkiNEIXSTO9rW2c+/caqaMKmH8sH5Bx5E0okIXibPfdo7Ob5g6IugokmZU6CJx1NQaYebcak4fUczJw/sHHUfSjApdJI4efWs92xtauUHXOpcAqNBF4qSpNcKvX6vm1GMGMLFMo3M58lToInHyu7c3sL2hhRumanQuwVChi8RBc1uEX79WxeSK/pxSMSDoOJKmVOgicfD42xuo29vCDVN1eVwJjgpd5DA1t0X41WtVTCrrz+QKzZ1LcFToIodp1qKNbNvTwg3njtRZoRIoFbrIYWhpj/CrP1cxYXg/Tj1Gc+cSLBW6yGF45r3NbKlv5rtTNTqX4KnQRT6laNSZ+Xo1owcVMGVkcdBxRFToIp/WKytrqaxt4JtTKjQ6l4SgQhf5lO6ZW8WQolwuHjco6CgiQIyFbmYXmNkqM6s0s5sPss+XzOwDM1tuZr+Lb0yRxPLO+l0sXLeL604vJ1OrEUmC6HGBCzMLA3cD5wE1wEIzm+3uH3TZZyRwC3Cau+8yMy3RIilt5twqCnMzuVJrhUoCiWVoMQmodPdqd28FHgcu22+fbwB3u/suAHevjW9MkcRRXdfAix9s46rJw8nL1qJfkjhiKfQhwMYu2zWdz3U1ChhlZm+Y2QIzu6C7T2RmM8xskZktqqur+3SJRQJ27+tryQyHuPrUsqCjiHxMLIXe3dv3vt92BjASOAuYDtxnZkUHfJD7THef4O4TSkpKPmlWkcDV7W3h9+/WcMX4Ukr6ZgcdR+RjYin0GqDrRGEpsLmbfZ5x9zZ3XwusoqPgRVLKb+avoy0S5RtnlAcdReQAsRT6QmCkmZWbWRYwDZi93z5/AM4GMLNiOqZgquMZVCRojS3tPLJgPZ8bczQVJflBxxE5QI+F7u7twPXAC8AKYJa7LzezH5jZpZ27vQDsMLMPgFeBf3T3Hb0VWiQITyzcSH1TGzPOrAg6iki3YnqL3t3nAHP2e+62Lo8duLHzJpJy2iJR7p+3lkll/Rk/rF/QcUS6pTMiRGLw3LKtbNrdxIwpGp1L4lKhi/TA3bn/9WoqivM45zidMyeJS4Uu0oN31u9icU0915xWRiiki3BJ4lKhi/Tg/nlrKczN5IqTS4OOInJIKnSRQ9i4cx8vLN/Kl08ZRp8sneYviU2FLnIID81fR8iMqz9bFnQUkR6p0EUOYm9zG08s3MjF4wZxdGFO0HFEeqRCFzmIJxZupKGlnetO12n+khxU6CLdiESdh+avY2JZP8aVHnCdOZGEpEIX6caLy7dSs6tJo3NJKip0kW7cP28tQ/vnct6Yo4OOIhIzFbrIfhZv3M2i9bu45tRywjqRSJKICl1kP/fPW0vf7Ay+pPVCJcmo0EW62FLfxLNLt3DlxKHka71QSTIqdJEuHpq/DnfXeqGSlFToIp0aW9p57K0NXDD2aIb27xN0HJFPTIUu0un379awp7md607XNc8lOanQRYBo1HnwjXWcOLSIk4drRSJJTip0EeCVlbWs3d6oE4kkqanQRYD75lUzuDCHC8fqRCJJXip0SXvLN9ezoHonV59aRkZYPxKSvPTdK2nv/nlr6ZMVZtqkYUFHETksKnRJa7V7mvm/xZv50oShFOZmBh1H5LCo0CWtPbJgPe1R55rTyoKOInLYVOiStprbIvx2wXrOHT2Q4QPygo4jcthU6JK2nnp3E7v2telQRUkZKnRJS+7OA2+s5fjBBZxS3j/oOCJxoUKXtPTa6joqaxu47vRyzHTNc0kNKnRJSzPnVjOwIJtLxg0OOopI3KjQJe0sralnftUOrju9nKwM/QhI6tB3s6Sde+ZW0Tc7g+k6kUhSTEyFbmYXmNkqM6s0s5sPsd8XzczNbEL8IorEz4Yd+5izdAtfnjyMvjk6kUhSS4+FbmZh4G7gQmAMMN3MxnSzX1/g74C34h1SJF7um1dNOGRce5oOVZTUE8sIfRJQ6e7V7t4KPA5c1s1+/wHcCTTHMZ9I3OxsbGXWoo184cQhDCzICTqOSNzFUuhDgI1dtms6n/uImZ0EDHX3Px7qE5nZDDNbZGaL6urqPnFYkcPx8JvraG6LMmOKViSS1BRLoXd3kK5/9KJZCPgv4KaePpG7z3T3Ce4+oaSkJPaUIoepqTXCw2+uZ+pxRzFyYN+g44j0ilgKvQYY2mW7FNjcZbsvMBb4s5mtAyYDs/XGqCSSJ9/ZyM7GVr555jFBRxHpNbEU+kJgpJmVm1kWMA2Y/eGL7l7v7sXuXubuZcAC4FJ3X9QriUU+oUjUuff1tZw0rIiJZVovVFJXj4Xu7u3A9cALwApglrsvN7MfmNmlvR1Q5HA9v2wrG3bu45tTKnSav6S0jFh2cvc5wJz9nrvtIPuedfixROLD3blnbhXlxXmcN0brhUpq05miktIWVO9kSU09Xz+jnHBIo3NJbSp0SWm/fGUNxfnZXDG+NOgoIr1OhS4pa+G6ncyv2sG3zqwgJzMcdByRXqdCl5R110trKM7P4iunDA86isgRoUKXlPTO+p3Mq9zOjCkV5GZpdC7pQYUuKemulysZkJfFVydrdC7pQ4UuKee9DbuYu7qOb0ypoE9WTEfmiqQEFbqknLteXkP/vCyu0uhc0owKXVLK+xt38+dVdXz9jHLysjU6l/SiQpeU8ouX11DUJ5O/+WxZ0FFEjjgVuqSMJTW7eWVlLV8/vZx8jc4lDanQJWX84uU1FOZmcvWpZUFHEQmECl1SwrJN9by0opbrTi/X4s+StlTokhJ+8sIqCnIy+NppZUFHEQmMCl2S3utr6nhtdR3XnzOCAo3OJY2p0CWpRaLOD59dQWm/XB3ZImlPhS5J7al3a1i5dS//dMFxuqKipD0VuiStptYI/+/F1XxmaBGfHzco6DgigVOhS9K6f141W/c0c+tFo7VWqAgqdElSdXtb+NWfqzh/zEAmlfcPOo5IQlChS1K66+XVtLRHufnC44KOIpIwVOiSdCpr9/LY2xv5yinDqCjJDzqOSMJQoUvSueO5lfTJDPN3U0cGHUUkoajQJam8WbWDl1bU8u2zRzAgPzvoOCIJRYUuSaO1Pcrts5czpCiXa3SKv8gBdI1RSRoz51axatte7r96gk4iEumGRuiSFKrqGvjFy5VcPG4QU0cPDDqOSEJSoUvCi0adW55aSk5miO9/fkzQcUQSlgpdEt4Tizby9tqd3HrxaI7qmxN0HJGEpUKXhFa7p5kfzVnB5Ir+fGnC0KDjiCS0mArdzC4ws1VmVmlmN3fz+o1m9oGZLTGzl81sePyjSjr6/uzltLRH+c/Lx+l6LSI96LHQzSwM3A1cCIwBppvZ/hOZ7wET3H0c8CRwZ7yDSvp5cflWnlu2lRumjqS8OC/oOCIJL5YR+iSg0t2r3b0VeBy4rOsO7v6qu+/r3FwAlMY3pqSbPc1t/Nszyzju6L7MmFIRdByRpBBLoQ8BNnbZrul87mCuA57r7gUzm2Fmi8xsUV1dXewpJe3855yV1O5t4Y4rxpEZ1ls9IrGI5Selu4lL73ZHs68CE4CfdPe6u8909wnuPqGkpCT2lJJW/m/xZh57ewMzzqjgxKFFQccRSRqxnClaA3Q9vKAU2Lz/TmZ2LnArcKa7t8QnnqSb6roGbv79Ek4e3o9/+NyxQccRSSqxjNAXAiPNrNzMsoBpwOyuO5jZScA9wKXuXhv/mJIOmtsifPvRd8nKCPHL6SdpqkXkE+rxJ8bd24HrgReAFcAsd19uZj8ws0s7d/sJkA/8r5m9b2azD/LpRA7q9tnLWbl1Lz+78kQGF+UGHUck6cR0cS53nwPM2e+527o8PjfOuSTNPP1eDY8v3Mi3zzqGs489Kug4IklJv9NK4Cpr9/IvTy1jUnl/bjxvVNBxRJKWCl0Cta+1nW8/+i59ssL8cvpJZGjeXORT0/XQJTDuzq1PL2NNbQOPXHsKAwt04S2Rw6HhkATmjudX8vR7m7jpvFGcPrI46DgiSU+FLoGYObeKe16r5qrJw/nO2SOCjiOSElTocsQ9+U4NP5qzkovHDeL2S4/XVRRF4kSFLkfUSx9s459/v4TTRxTzsy99hnBIZS4SLyp0OWIWrtvJd373LscPLuDXV51MdoYWehaJJxW6HBErtuzh2ocWMqQolwe/NpH8bB1gJRJvKnTpdUtqdnPV/W/RJyvMw9dNYkB+dtCRRFKSCl161aurapk2cwHZGWEe/fpkSvv1CTqSSMrS773Sa2Yt3MgtTy/l2IF9eeiaiRylE4dEepUKXeLO3bnr5TX8/KU1nDGymP/5ynj65mQGHUsk5anQJa7aI1H+9Q/LeHzhRi4fP4Qfawk5kSNGhS5xs7Oxlb9/4n1eW13H9WeP4KbzR+mkIZEjSIUucfHa6jr+4X8Xs3tfKz/8q7F85ZThQUcSSTsqdDkszW0Rfvz8Sh58Yx0jj8rnN9dMYszggqBjiaQlFbp8aiu37uGGx95n1ba9fO3UMm6+8DhyMnX2p0hQVOjyibVHojw0fx13Pr+KgtxMHrxmopaNE0kAKnSJmbvz6qpafjRnJZW1DZw7eiA/vuIEnfkpkiBU6BKT5Zvr+dGcFbxRuYPy4jzuuepkzh8zUEexiCQQFboc0tb6Zn764ip+/24NRbmZ3P75MXxl8nAdWy6SgFTo0q3V2/by4BvrePq9GqJR+MYZFXzn7BEU5uqMT5FEpUKXj0Sjzmur63jgjbW8vmY72RkhvnDiEK4/ZwRD++uiWiKJToUu7GpsZfbizfxm/jqqtzcysCCbf/zcsUyfNIz+eVlBxxORGKnQ01T9vjZeWL6VPy7dwhuV24lEnROHFnHXtBO56IRBmiMXSUIq9DRSt7eF11bX8eySzcyr3E5bxBnWvw8zplRwybhBHD+4MOiIInIYVOgprL6pjbeqdzC/agfzq7azelsDAEOKcrn2tHIuGTeYsUMKdOihSIpQoaeI9kiUqrpGlm6qZ9mmet7bsIulm+qJOuRkhphY1p+/OqmU00cUq8RFUpQKPcm4O7V7W6iqa6C6rpE12/aydFM9H2zZQ3NbFIA+WWHGDi7k+nNGctoxAzhxWBHZGbrGikiqU6EnoMaWdrbUN7FpdzObdzexeXcTG3buo7qukbXbG2loaf9o3z5ZYY4fXMD0ScM4YUgh40oLKS/OJxzSCFwk3cRU6GZ2AXAXEAbuc/c79ns9G3gYOBnYAVzp7uviGzU5uTvNbVHqm9o+uu3e18qufa1sb2hle0MLO7rcb9vbzO59bR/7HCGDQYW5VJTkccX4IVSU5FNRkkdFST6DCnIIqbxFhBgK3czCwN3AeUANsNDMZrv7B112uw7Y5e4jzGwa8GPgyt4IfDiiUac96kSiTns0SnvEaYtGaYs47ZEobZGOx22RKK3tUVraP7yP0NK53dIWoaktQlNrlKa2CM1tEZpaIzS2ttPY0k5jS4SGlvaPtvc0tdMaiR40U352BgPysyjOz2b4gD5MLO/H4KJchhTlMrjzNrBvNhk6jFBEehDLCH0SUOnu1QBm9jhwGdC10C8Dbu98/CTw32Zm7u5xzArAEws3MHNuNe4QcSfqTjRKx713lPWHt6hDezRKNNp5H+c0WeEQOZkhcjLD5GdnkJedQV52mMFFOZ2PM+ibk0FhbiaFuZkU5Wb95XGfTIrzs8nN0ty2iMRHLIU+BNjYZbsGOOVg+7h7u5nVAwOA7V13MrMZwAyAYcOGfarA/fOyOW5QASEzQgZhM6zzcciMcNgImxEO/eUWMiMz3PE4I2RkhENkdL6WGQ6RGf7wPvTRdlZGiOyMcOd9iKyMEFnhELlZYXIzw+RkhjVPLSIJJZZC76619h/rxrIP7j4TmAkwYcKETzVePm/MQM4bM/DTfKiISEqLZWK2BhjaZbsU2HywfcwsAygEdsYjoIiIxCaWQl8IjDSzcjPLAqYBs/fbZzZwdefjLwKv9Mb8uYiIHFyPUy6dc+LXAy/QcdjiA+6+3Mx+ACxy99nA/cAjZlZJx8h8Wm+GFhGRA8V0HLq7zwHm7PfcbV0eNwN/Hd9oIiLySejgZhGRFKFCFxFJESp0EZEUoUIXEUkRFtTRhWZWB6wP5IsfXDH7nd2a4JIpr7L2nmTKm0xZITHzDnf3ku5eCKzQE5GZLXL3CUHniFUy5VXW3pNMeZMpKyRfXk25iIikCBW6iEiKUKF/3MygA3xCyZRXWXtPMuVNpqyQZHk1hy4ikiI0QhcRSREqdBGRFKFC74aZfdfMVpnZcjO7M+g8PTGzfzAzN7PioLMcipn9xMxWmtkSM3vazIqCzrQ/M7ug89++0sxuDjrPoZjZUDN71cxWdH6v3hB0pp6YWdjM3jOzPwad5VDMrMjMnuz8fl1hZp8NOlMsVOj7MbOz6VgjdZy7Hw/8NOBIh2RmQ+lYwHtD0Fli8CdgrLuPA1YDtwSc52O6LIh+ITAGmG5mY4JNdUjtwE3uPhqYDHwnwfMC3ACsCDpEDO4Cnnf344DPkByZVejd+FvgDndvAXD32oDz9OS/gH+imyX/Eo27v+ju7Z2bC+hY/SqRfLQguru3Ah8uiJ6Q3H2Lu7/b+XgvHaUzJNhUB2dmpcDFwH1BZzkUMysAptCxzgPu3uruu4NNFRsV+oFGAWeY2Vtm9pqZTQw60MGY2aXAJndfHHSWT+Fa4LmgQ+ynuwXRE7YguzKzMuAk4K1gkxzSz+kYfESDDtKDCqAOeLBzeug+M8sLOlQsYlrgItWY2UvA0d28dCsdfyf96PgVdiIwy8wqglpSr4es/wKcf2QTHdqh8rr7M5373ErHdMGjRzJbDGJa7DzRmFk+8Hvge+6+J+g83TGzS4Bad3/HzM4KOk8PMoDxwHfd/S0zuwu4Gfi3YGP1LC0L3d3PPdhrZva3wFOdBf62mUXpuEBP3ZHK19XBsprZCUA5sNjMoGP64l0zm+TuW49gxI851N8tgJldDVwCTE3AdWdjWRA9oZhZJh1l/qi7PxV0nkM4DbjUzC4CcoACM/utu3814FzdqQFq3P3D33aepKPQE56mXA70B+AcADMbBWSReFdbw92XuvtR7l7m7mV0fBOOD7LMe2JmFwD/DFzq7vuCztONWBZETxjW8T/5/cAKd/9Z0HkOxd1vcffSzu/VaXQsJJ+IZU7nz9BGMzu286mpwAcBRopZWo7Qe/AA8ICZLQNagasTcCSZrP4byAb+1PlbxQJ3/1awkf7iYAuiBxzrUE4DrgKWmtn7nc/9S+cawHJ4vgs82vkfezVwTcB5YqJT/0VEUoSmXEREUoQKXUQkRajQRURShApdRCRFqNBFRFKECl1EJEWo0EVEUsT/B5oxTW3I3ynjAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plt.plot(z, sigmoid(z))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 60,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def linear_regression(xi):\n",
-    "    result = w0\n",
-    "    \n",
-    "    for j in range(len(w)):\n",
-    "        result = result + xi[j] * w[j]\n",
-    "        \n",
-    "    return result"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 61,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def logistic_regression(xi):\n",
-    "    score = w0\n",
-    "    \n",
-    "    for j in range(len(w)):\n",
-    "        score = score + xi[j] * w[j]\n",
-    "        \n",
-    "    result = sigmoid(score)\n",
-    "    return result"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.10 Training logistic regression with Scikit-Learn\n",
-    "\n",
-    "* Train a model with Scikit-Learn\n",
-    "* Apply it to the validation dataset\n",
-    "* Calculate the accuracy"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 62,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.linear_model import LogisticRegression"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 63,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "KL9Ja82EF5zv",
+        "outputId": "7864e65f-bf61-447a-e0be-4686add77b0f"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(4225, 1409, 1409)"
+            ]
+          },
+          "execution_count": 14,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "len(df_train), len(df_val), len(df_test)"
+      ],
+      "id": "KL9Ja82EF5zv"
+    },
     {
-     "data": {
-      "text/plain": [
-       "LogisticRegression(C=1.0, class_weight=None, dual=False, fit_intercept=True,\n",
-       "                   intercept_scaling=1, l1_ratio=None, max_iter=100,\n",
-       "                   multi_class='warn', n_jobs=None, penalty='l2',\n",
-       "                   random_state=None, solver='lbfgs', tol=0.0001, verbose=0,\n",
-       "                   warm_start=False)"
-      ]
-     },
-     "execution_count": 63,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "model = LogisticRegression(solver='lbfgs')\n",
-    "# solver='lbfgs' is the default solver in newer version of sklearn\n",
-    "# for older versions, you need to specify it explicitly\n",
-    "model.fit(X_train, y_train)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 64,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "b6-JkdOGF5zv"
+      },
+      "outputs": [],
+      "source": [
+        "df_train = df_train.reset_index(drop=True)\n",
+        "df_val = df_val.reset_index(drop=True)\n",
+        "df_test = df_test.reset_index(drop=True)"
+      ],
+      "id": "b6-JkdOGF5zv"
+    },
     {
-     "data": {
-      "text/plain": [
-       "-0.10903395348323511"
-      ]
-     },
-     "execution_count": 64,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "model.intercept_[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 65,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "dkMBkCpmF5zw"
+      },
+      "outputs": [],
+      "source": [
+        "y_train = df_train.churn.values\n",
+        "y_val = df_val.churn.values\n",
+        "y_test = df_test.churn.values\n",
+        "\n",
+        "del df_train['churn']\n",
+        "del df_val['churn']\n",
+        "del df_test['churn']"
+      ],
+      "id": "dkMBkCpmF5zw"
+    },
     {
-     "data": {
-      "text/plain": [
-       "array([ 0.475, -0.175, -0.408, -0.03 , -0.078,  0.063, -0.089, -0.081,\n",
-       "       -0.034, -0.073, -0.335,  0.316, -0.089,  0.004, -0.258,  0.141,\n",
-       "        0.009,  0.063, -0.089, -0.081,  0.266, -0.089, -0.284, -0.231,\n",
-       "        0.124, -0.166,  0.058, -0.087, -0.032,  0.07 , -0.059,  0.141,\n",
-       "       -0.249,  0.215, -0.12 , -0.089,  0.102, -0.071, -0.089,  0.052,\n",
-       "        0.213, -0.089, -0.232, -0.07 ,  0.   ])"
-      ]
-     },
-     "execution_count": 65,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "model.coef_[0].round(3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 66,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "y_pred = model.predict_proba(X_val)[:, 1]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 67,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "churn_decision = (y_pred >= 0.5)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 68,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "w99Q78NnF5zw"
+      },
+      "source": [
+        "## 3.4 EDA\n",
+        "\n",
+        "* Check missing values\n",
+        "* Look at the target variable (churn)\n",
+        "* Look at numerical and categorical variables"
+      ],
+      "id": "w99Q78NnF5zw"
+    },
     {
-     "data": {
-      "text/plain": [
-       "0.8034066713981547"
-      ]
-     },
-     "execution_count": 68,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "(y_val == churn_decision).mean()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 69,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_pred = pd.DataFrame()\n",
-    "df_pred['probability'] = y_pred\n",
-    "df_pred['prediction'] = churn_decision.astype(int)\n",
-    "df_pred['actual'] = y_val"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 70,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_pred['correct'] = df_pred.prediction == df_pred.actual"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 71,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "SoYSVmlJF5zw"
+      },
+      "outputs": [],
+      "source": [
+        "df_full_train = df_full_train.reset_index(drop=True)"
+      ],
+      "id": "SoYSVmlJF5zw"
+    },
     {
-     "data": {
-      "text/plain": [
-       "0.8034066713981547"
-      ]
-     },
-     "execution_count": 71,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_pred.correct.mean()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 72,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "P1oja73kF5zx",
+        "outputId": "44623b79-8fad-40a6-ffb7-66e2d156c30d"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "customerid          0\n",
+              "gender              0\n",
+              "seniorcitizen       0\n",
+              "partner             0\n",
+              "dependents          0\n",
+              "tenure              0\n",
+              "phoneservice        0\n",
+              "multiplelines       0\n",
+              "internetservice     0\n",
+              "onlinesecurity      0\n",
+              "onlinebackup        0\n",
+              "deviceprotection    0\n",
+              "techsupport         0\n",
+              "streamingtv         0\n",
+              "streamingmovies     0\n",
+              "contract            0\n",
+              "paperlessbilling    0\n",
+              "paymentmethod       0\n",
+              "monthlycharges      0\n",
+              "totalcharges        0\n",
+              "churn               0\n",
+              "dtype: int64"
+            ]
+          },
+          "execution_count": 18,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_full_train.isnull().sum()"
+      ],
+      "id": "P1oja73kF5zx"
+    },
     {
-     "data": {
-      "text/plain": [
-       "array([0, 0, 0, ..., 0, 1, 1])"
-      ]
-     },
-     "execution_count": 72,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "churn_decision.astype(int)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.11 Model interpretation\n",
-    "\n",
-    "* Look at the coefficients\n",
-    "* Train a smaller model with fewer features"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 73,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "a = [1, 2, 3, 4]\n",
-    "b = 'abcd'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 74,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "QuZbWNdfF5zx",
+        "outputId": "25e0db0b-462a-4cb7-9208-d60072645eb5"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0    0.730032\n",
+              "1    0.269968\n",
+              "Name: churn, dtype: float64"
+            ]
+          },
+          "execution_count": 19,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_full_train.churn.value_counts(normalize=True)"
+      ],
+      "id": "QuZbWNdfF5zx"
+    },
     {
-     "data": {
-      "text/plain": [
-       "{1: 'a', 2: 'b', 3: 'c', 4: 'd'}"
-      ]
-     },
-     "execution_count": 74,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dict(zip(a, b))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 75,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "LAE26n5DF5zy",
+        "outputId": "2ce878b3-df08-4922-b23f-a7c82438fdfc"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.26996805111821087"
+            ]
+          },
+          "execution_count": 20,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_full_train.churn.mean()"
+      ],
+      "id": "LAE26n5DF5zy"
+    },
     {
-     "data": {
-      "text/plain": [
-       "{'contract=month-to-month': 0.475,\n",
-       " 'contract=one_year': -0.175,\n",
-       " 'contract=two_year': -0.408,\n",
-       " 'dependents=no': -0.03,\n",
-       " 'dependents=yes': -0.078,\n",
-       " 'deviceprotection=no': 0.063,\n",
-       " 'deviceprotection=no_internet_service': -0.089,\n",
-       " 'deviceprotection=yes': -0.081,\n",
-       " 'gender=female': -0.034,\n",
-       " 'gender=male': -0.073,\n",
-       " 'internetservice=dsl': -0.335,\n",
-       " 'internetservice=fiber_optic': 0.316,\n",
-       " 'internetservice=no': -0.089,\n",
-       " 'monthlycharges': 0.004,\n",
-       " 'multiplelines=no': -0.258,\n",
-       " 'multiplelines=no_phone_service': 0.141,\n",
-       " 'multiplelines=yes': 0.009,\n",
-       " 'onlinebackup=no': 0.063,\n",
-       " 'onlinebackup=no_internet_service': -0.089,\n",
-       " 'onlinebackup=yes': -0.081,\n",
-       " 'onlinesecurity=no': 0.266,\n",
-       " 'onlinesecurity=no_internet_service': -0.089,\n",
-       " 'onlinesecurity=yes': -0.284,\n",
-       " 'paperlessbilling=no': -0.231,\n",
-       " 'paperlessbilling=yes': 0.124,\n",
-       " 'partner=no': -0.166,\n",
-       " 'partner=yes': 0.058,\n",
-       " 'paymentmethod=bank_transfer_(automatic)': -0.087,\n",
-       " 'paymentmethod=credit_card_(automatic)': -0.032,\n",
-       " 'paymentmethod=electronic_check': 0.07,\n",
-       " 'paymentmethod=mailed_check': -0.059,\n",
-       " 'phoneservice=no': 0.141,\n",
-       " 'phoneservice=yes': -0.249,\n",
-       " 'seniorcitizen': 0.215,\n",
-       " 'streamingmovies=no': -0.12,\n",
-       " 'streamingmovies=no_internet_service': -0.089,\n",
-       " 'streamingmovies=yes': 0.102,\n",
-       " 'streamingtv=no': -0.071,\n",
-       " 'streamingtv=no_internet_service': -0.089,\n",
-       " 'streamingtv=yes': 0.052,\n",
-       " 'techsupport=no': 0.213,\n",
-       " 'techsupport=no_internet_service': -0.089,\n",
-       " 'techsupport=yes': -0.232,\n",
-       " 'tenure': -0.07,\n",
-       " 'totalcharges': 0.0}"
-      ]
-     },
-     "execution_count": 75,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dict(zip(dv.get_feature_names(), model.coef_[0].round(3)))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 76,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "small = ['contract', 'tenure', 'monthlycharges']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 77,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "yPHsvxtOF5zy"
+      },
+      "outputs": [],
+      "source": [
+        "numerical = ['tenure', 'monthlycharges', 'totalcharges']"
+      ],
+      "id": "yPHsvxtOF5zy"
+    },
     {
-     "data": {
-      "text/plain": [
-       "[{'contract': 'two_year', 'tenure': 72, 'monthlycharges': 115.5},\n",
-       " {'contract': 'month-to-month', 'tenure': 10, 'monthlycharges': 95.25},\n",
-       " {'contract': 'month-to-month', 'tenure': 5, 'monthlycharges': 75.55},\n",
-       " {'contract': 'month-to-month', 'tenure': 5, 'monthlycharges': 80.85},\n",
-       " {'contract': 'two_year', 'tenure': 18, 'monthlycharges': 20.1},\n",
-       " {'contract': 'month-to-month', 'tenure': 4, 'monthlycharges': 30.5},\n",
-       " {'contract': 'month-to-month', 'tenure': 1, 'monthlycharges': 75.1},\n",
-       " {'contract': 'month-to-month', 'tenure': 1, 'monthlycharges': 70.3},\n",
-       " {'contract': 'two_year', 'tenure': 72, 'monthlycharges': 19.75},\n",
-       " {'contract': 'month-to-month', 'tenure': 6, 'monthlycharges': 109.9}]"
-      ]
-     },
-     "execution_count": 77,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_train[small].iloc[:10].to_dict(orient='records')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 78,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dicts_train_small = df_train[small].to_dict(orient='records')\n",
-    "dicts_val_small = df_val[small].to_dict(orient='records')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 79,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "2s9EZQHNF5zy"
+      },
+      "outputs": [],
+      "source": [
+        "categorical = [\n",
+        "    'gender',\n",
+        "    'seniorcitizen',\n",
+        "    'partner',\n",
+        "    'dependents',\n",
+        "    'phoneservice',\n",
+        "    'multiplelines',\n",
+        "    'internetservice',\n",
+        "    'onlinesecurity',\n",
+        "    'onlinebackup',\n",
+        "    'deviceprotection',\n",
+        "    'techsupport',\n",
+        "    'streamingtv',\n",
+        "    'streamingmovies',\n",
+        "    'contract',\n",
+        "    'paperlessbilling',\n",
+        "    'paymentmethod',\n",
+        "]"
+      ],
+      "id": "2s9EZQHNF5zy"
+    },
     {
-     "data": {
-      "text/plain": [
-       "DictVectorizer(dtype=<class 'numpy.float64'>, separator='=', sort=True,\n",
-       "               sparse=False)"
-      ]
-     },
-     "execution_count": 79,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dv_small = DictVectorizer(sparse=False)\n",
-    "dv_small.fit(dicts_train_small)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 80,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "W0dCe9bXF5zz",
+        "outputId": "283742c7-897a-4954-ca97-2a190c483f0a"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "gender              2\n",
+              "seniorcitizen       2\n",
+              "partner             2\n",
+              "dependents          2\n",
+              "phoneservice        2\n",
+              "multiplelines       3\n",
+              "internetservice     3\n",
+              "onlinesecurity      3\n",
+              "onlinebackup        3\n",
+              "deviceprotection    3\n",
+              "techsupport         3\n",
+              "streamingtv         3\n",
+              "streamingmovies     3\n",
+              "contract            3\n",
+              "paperlessbilling    2\n",
+              "paymentmethod       4\n",
+              "dtype: int64"
+            ]
+          },
+          "execution_count": 23,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_full_train[categorical].nunique()"
+      ],
+      "id": "W0dCe9bXF5zz"
+    },
     {
-     "data": {
-      "text/plain": [
-       "['contract=month-to-month',\n",
-       " 'contract=one_year',\n",
-       " 'contract=two_year',\n",
-       " 'monthlycharges',\n",
-       " 'tenure']"
-      ]
-     },
-     "execution_count": 80,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dv_small.get_feature_names()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 81,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X_train_small = dv_small.transform(dicts_train_small)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 82,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dFJ_aPP1F5z0"
+      },
+      "source": [
+        "## 3.5 Feature importance: Churn rate and risk ratio\n",
+        "\n",
+        "Feature importance analysis (part of EDA) - identifying which features affect our target variable\n",
+        "\n",
+        "* Churn rate\n",
+        "* Risk ratio\n",
+        "* Mutual information - later"
+      ],
+      "id": "dFJ_aPP1F5z0"
+    },
     {
-     "data": {
-      "text/plain": [
-       "LogisticRegression(C=1.0, class_weight=None, dual=False, fit_intercept=True,\n",
-       "                   intercept_scaling=1, l1_ratio=None, max_iter=100,\n",
-       "                   multi_class='warn', n_jobs=None, penalty='l2',\n",
-       "                   random_state=None, solver='lbfgs', tol=0.0001, verbose=0,\n",
-       "                   warm_start=False)"
-      ]
-     },
-     "execution_count": 82,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "model_small = LogisticRegression(solver='lbfgs')\n",
-    "model_small.fit(X_train_small, y_train)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 83,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ZaX3KmMMF5z0"
+      },
+      "source": [
+        "#### Churn rate"
+      ],
+      "id": "ZaX3KmMMF5z0"
+    },
     {
-     "data": {
-      "text/plain": [
-       "-2.476775657751665"
-      ]
-     },
-     "execution_count": 83,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "w0 = model_small.intercept_[0]\n",
-    "w0"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 84,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "SDJjpgZOF5z0",
+        "outputId": "c9c54957-b3fb-4391-edd0-e838a87607a7"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>customerid</th>\n",
+              "      <th>gender</th>\n",
+              "      <th>seniorcitizen</th>\n",
+              "      <th>partner</th>\n",
+              "      <th>dependents</th>\n",
+              "      <th>tenure</th>\n",
+              "      <th>phoneservice</th>\n",
+              "      <th>multiplelines</th>\n",
+              "      <th>internetservice</th>\n",
+              "      <th>onlinesecurity</th>\n",
+              "      <th>...</th>\n",
+              "      <th>deviceprotection</th>\n",
+              "      <th>techsupport</th>\n",
+              "      <th>streamingtv</th>\n",
+              "      <th>streamingmovies</th>\n",
+              "      <th>contract</th>\n",
+              "      <th>paperlessbilling</th>\n",
+              "      <th>paymentmethod</th>\n",
+              "      <th>monthlycharges</th>\n",
+              "      <th>totalcharges</th>\n",
+              "      <th>churn</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>5442-pptjy</td>\n",
+              "      <td>male</td>\n",
+              "      <td>0</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>12</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no_internet_service</td>\n",
+              "      <td>...</td>\n",
+              "      <td>no_internet_service</td>\n",
+              "      <td>no_internet_service</td>\n",
+              "      <td>no_internet_service</td>\n",
+              "      <td>no_internet_service</td>\n",
+              "      <td>two_year</td>\n",
+              "      <td>no</td>\n",
+              "      <td>mailed_check</td>\n",
+              "      <td>19.70</td>\n",
+              "      <td>258.35</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>6261-rcvns</td>\n",
+              "      <td>female</td>\n",
+              "      <td>0</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>42</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "      <td>dsl</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>...</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>one_year</td>\n",
+              "      <td>no</td>\n",
+              "      <td>credit_card_(automatic)</td>\n",
+              "      <td>73.90</td>\n",
+              "      <td>3160.55</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>2176-osjuv</td>\n",
+              "      <td>male</td>\n",
+              "      <td>0</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "      <td>71</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>dsl</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>...</td>\n",
+              "      <td>no</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>two_year</td>\n",
+              "      <td>no</td>\n",
+              "      <td>bank_transfer_(automatic)</td>\n",
+              "      <td>65.15</td>\n",
+              "      <td>4681.75</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>6161-erdgd</td>\n",
+              "      <td>male</td>\n",
+              "      <td>0</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>71</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>dsl</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>...</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>one_year</td>\n",
+              "      <td>no</td>\n",
+              "      <td>electronic_check</td>\n",
+              "      <td>85.45</td>\n",
+              "      <td>6300.85</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>2364-ufrom</td>\n",
+              "      <td>male</td>\n",
+              "      <td>0</td>\n",
+              "      <td>no</td>\n",
+              "      <td>no</td>\n",
+              "      <td>30</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "      <td>dsl</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>...</td>\n",
+              "      <td>no</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>yes</td>\n",
+              "      <td>no</td>\n",
+              "      <td>one_year</td>\n",
+              "      <td>no</td>\n",
+              "      <td>electronic_check</td>\n",
+              "      <td>70.40</td>\n",
+              "      <td>2044.75</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>5 rows × 21 columns</p>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   customerid  gender  seniorcitizen partner dependents  tenure phoneservice  \\\n",
+              "0  5442-pptjy    male              0     yes        yes      12          yes   \n",
+              "1  6261-rcvns  female              0      no         no      42          yes   \n",
+              "2  2176-osjuv    male              0     yes         no      71          yes   \n",
+              "3  6161-erdgd    male              0     yes        yes      71          yes   \n",
+              "4  2364-ufrom    male              0      no         no      30          yes   \n",
+              "\n",
+              "  multiplelines internetservice       onlinesecurity  ...  \\\n",
+              "0            no              no  no_internet_service  ...   \n",
+              "1            no             dsl                  yes  ...   \n",
+              "2           yes             dsl                  yes  ...   \n",
+              "3           yes             dsl                  yes  ...   \n",
+              "4            no             dsl                  yes  ...   \n",
+              "\n",
+              "      deviceprotection          techsupport          streamingtv  \\\n",
+              "0  no_internet_service  no_internet_service  no_internet_service   \n",
+              "1                  yes                  yes                   no   \n",
+              "2                   no                  yes                   no   \n",
+              "3                  yes                  yes                  yes   \n",
+              "4                   no                  yes                  yes   \n",
+              "\n",
+              "       streamingmovies  contract paperlessbilling              paymentmethod  \\\n",
+              "0  no_internet_service  two_year               no               mailed_check   \n",
+              "1                  yes  one_year               no    credit_card_(automatic)   \n",
+              "2                   no  two_year               no  bank_transfer_(automatic)   \n",
+              "3                  yes  one_year               no           electronic_check   \n",
+              "4                   no  one_year               no           electronic_check   \n",
+              "\n",
+              "  monthlycharges  totalcharges  churn  \n",
+              "0          19.70        258.35      0  \n",
+              "1          73.90       3160.55      1  \n",
+              "2          65.15       4681.75      0  \n",
+              "3          85.45       6300.85      0  \n",
+              "4          70.40       2044.75      0  \n",
+              "\n",
+              "[5 rows x 21 columns]"
+            ]
+          },
+          "execution_count": 24,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_full_train.head()"
+      ],
+      "id": "SDJjpgZOF5z0"
+    },
     {
-     "data": {
-      "text/plain": [
-       "array([ 0.97 , -0.025, -0.949,  0.027, -0.036])"
-      ]
-     },
-     "execution_count": 84,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "w = model_small.coef_[0]\n",
-    "w.round(3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 85,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bzE72UJOF5z1",
+        "outputId": "441a2898-e748-4498-f8c9-23882a7ad973"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.27682403433476394"
+            ]
+          },
+          "execution_count": 25,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "churn_female = df_full_train[df_full_train.gender == 'female'].churn.mean()\n",
+        "churn_female"
+      ],
+      "id": "bzE72UJOF5z1"
+    },
     {
-     "data": {
-      "text/plain": [
-       "{'contract=month-to-month': 0.97,\n",
-       " 'contract=one_year': -0.025,\n",
-       " 'contract=two_year': -0.949,\n",
-       " 'monthlycharges': 0.027,\n",
-       " 'tenure': -0.036}"
-      ]
-     },
-     "execution_count": 85,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dict(zip(dv_small.get_feature_names(), w.round(3)))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 86,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "8Wq50uaLF5z1",
+        "outputId": "53be1895-f3a5-4fe6-f9bc-b09caaf2f6c8"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.2632135306553911"
+            ]
+          },
+          "execution_count": 26,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "churn_male = df_full_train[df_full_train.gender == 'male'].churn.mean()\n",
+        "churn_male"
+      ],
+      "id": "8Wq50uaLF5z1"
+    },
     {
-     "data": {
-      "text/plain": [
-       "-3.473"
-      ]
-     },
-     "execution_count": 86,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "-2.47 + (-0.949) + 30 * 0.027 + 24 * (-0.036)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 87,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "dO9HjHnMF5z1",
+        "outputId": "48c74494-802b-496e-af27-fc4ae2cf92d8"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.26996805111821087"
+            ]
+          },
+          "execution_count": 27,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "global_churn = df_full_train.churn.mean()\n",
+        "global_churn"
+      ],
+      "id": "dO9HjHnMF5z1"
+    },
     {
-     "data": {
-      "text/plain": [
-       "0.030090303318277657"
-      ]
-     },
-     "execution_count": 87,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sigmoid(_)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.12 Using the model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 88,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dicts_full_train = df_full_train[categorical + numerical].to_dict(orient='records')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 89,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dv = DictVectorizer(sparse=False)\n",
-    "X_full_train = dv.fit_transform(dicts_full_train)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 90,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "y_full_train = df_full_train.churn.values"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 91,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "9Y-L14ThF5z1",
+        "outputId": "d566887a-0fae-497f-8362-54added9fb8c"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "-0.006855983216553063"
+            ]
+          },
+          "execution_count": 28,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "global_churn - churn_female"
+      ],
+      "id": "9Y-L14ThF5z1"
+    },
     {
-     "data": {
-      "text/plain": [
-       "LogisticRegression(C=1.0, class_weight=None, dual=False, fit_intercept=True,\n",
-       "                   intercept_scaling=1, l1_ratio=None, max_iter=100,\n",
-       "                   multi_class='warn', n_jobs=None, penalty='l2',\n",
-       "                   random_state=None, solver='lbfgs', tol=0.0001, verbose=0,\n",
-       "                   warm_start=False)"
-      ]
-     },
-     "execution_count": 91,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "model = LogisticRegression(solver='lbfgs')\n",
-    "model.fit(X_full_train, y_full_train)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 92,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dicts_test = df_test[categorical + numerical].to_dict(orient='records')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 93,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X_test = dv.transform(dicts_test)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 94,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "y_pred = model.predict_proba(X_test)[:, 1]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 95,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "churn_decision = (y_pred >= 0.5)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 96,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "EgJyiuBDF5z2",
+        "outputId": "5e675fdc-5549-4a51-f295-920a3bd8040b"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.006754520462819769"
+            ]
+          },
+          "execution_count": 29,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "global_churn - churn_male"
+      ],
+      "id": "EgJyiuBDF5z2"
+    },
     {
-     "data": {
-      "text/plain": [
-       "0.815471965933286"
-      ]
-     },
-     "execution_count": 96,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "(churn_decision == y_test).mean()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 97,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "X8LJoQikF5z2",
+        "outputId": "942b3a25-797a-4d22-8278-ed5847fd6fb0"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "no     2932\n",
+              "yes    2702\n",
+              "Name: partner, dtype: int64"
+            ]
+          },
+          "execution_count": 30,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_full_train.partner.value_counts()"
+      ],
+      "id": "X8LJoQikF5z2"
+    },
     {
-     "data": {
-      "text/plain": [
-       "array([0, 0, 0, ..., 0, 0, 1])"
-      ]
-     },
-     "execution_count": 97,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "y_test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 98,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "yKyYEW7ZF5z2",
+        "outputId": "e82923f5-86c9-408b-9d4b-2ac73c0c7e23"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.20503330866025166"
+            ]
+          },
+          "execution_count": 31,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "churn_partner = df_full_train[df_full_train.partner == 'yes'].churn.mean()\n",
+        "churn_partner"
+      ],
+      "id": "yKyYEW7ZF5z2"
+    },
     {
-     "data": {
-      "text/plain": [
-       "{'gender': 'female',\n",
-       " 'seniorcitizen': 0,\n",
-       " 'partner': 'yes',\n",
-       " 'dependents': 'yes',\n",
-       " 'phoneservice': 'yes',\n",
-       " 'multiplelines': 'yes',\n",
-       " 'internetservice': 'fiber_optic',\n",
-       " 'onlinesecurity': 'yes',\n",
-       " 'onlinebackup': 'no',\n",
-       " 'deviceprotection': 'yes',\n",
-       " 'techsupport': 'no',\n",
-       " 'streamingtv': 'yes',\n",
-       " 'streamingmovies': 'yes',\n",
-       " 'contract': 'month-to-month',\n",
-       " 'paperlessbilling': 'yes',\n",
-       " 'paymentmethod': 'electronic_check',\n",
-       " 'tenure': 17,\n",
-       " 'monthlycharges': 104.2,\n",
-       " 'totalcharges': 1743.5}"
-      ]
-     },
-     "execution_count": 98,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "customer = dicts_test[-1]\n",
-    "customer"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 99,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X_small = dv.transform([customer])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 100,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "nTE5saukF5z2",
+        "outputId": "b1927584-5b51-4e6e-dc94-9791154ed074"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.06493474245795922"
+            ]
+          },
+          "execution_count": 32,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "global_churn - churn_partner"
+      ],
+      "id": "nTE5saukF5z2"
+    },
     {
-     "data": {
-      "text/plain": [
-       "0.5968852088293909"
-      ]
-     },
-     "execution_count": 100,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "model.predict_proba(X_small)[0, 1]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 101,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "BeoGdeuqF5z3",
+        "outputId": "8d20e53d-0742-4ee5-ffaa-a2361de7afea"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.3298090040927694"
+            ]
+          },
+          "execution_count": 33,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "churn_no_partner = df_full_train[df_full_train.partner == 'no'].churn.mean()\n",
+        "churn_no_partner"
+      ],
+      "id": "BeoGdeuqF5z3"
+    },
     {
-     "data": {
-      "text/plain": [
-       "1"
-      ]
-     },
-     "execution_count": 101,
-     "metadata": {},
-     "output_type": "execute_result"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "N417IBO5F5z3",
+        "outputId": "ffdf1d77-c272-4ada-ad8c-c0f7c7143226"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "-0.05984095297455855"
+            ]
+          },
+          "execution_count": 34,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "global_churn - churn_no_partner"
+      ],
+      "id": "N417IBO5F5z3"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CyTVE9y-F5z3"
+      },
+      "source": [
+        "#### Risk ratio"
+      ],
+      "id": "CyTVE9y-F5z3"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "hmUDKBmPF5z4",
+        "outputId": "936878d5-0434-4a21-a721-f238afea3825"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "1.2216593879412643"
+            ]
+          },
+          "execution_count": 35,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "churn_no_partner / global_churn"
+      ],
+      "id": "hmUDKBmPF5z4"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "kEHH2xTHF5z4",
+        "outputId": "6b500eae-fa00-44b6-f253-ead250bb64be"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.7594724924338315"
+            ]
+          },
+          "execution_count": 36,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "churn_partner / global_churn"
+      ],
+      "id": "kEHH2xTHF5z4"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-BtmfOmUF5z4"
+      },
+      "source": [
+        "```\n",
+        "SELECT\n",
+        "    gender,\n",
+        "    AVG(churn),\n",
+        "    AVG(churn) - global_churn AS diff,\n",
+        "    AVG(churn) / global_churn AS risk\n",
+        "FROM\n",
+        "    data\n",
+        "GROUP BY\n",
+        "    gender;\n",
+        "```"
+      ],
+      "id": "-BtmfOmUF5z4"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "PmVefyhWF5z4"
+      },
+      "outputs": [],
+      "source": [
+        "from IPython.display import display"
+      ],
+      "id": "PmVefyhWF5z4"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "uITS8r8_F5z5",
+        "outputId": "730c768a-8743-497a-d54c-da70df884099"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "gender\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>gender</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>female</th>\n",
+              "      <td>0.276824</td>\n",
+              "      <td>2796</td>\n",
+              "      <td>0.006856</td>\n",
+              "      <td>1.025396</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>male</th>\n",
+              "      <td>0.263214</td>\n",
+              "      <td>2838</td>\n",
+              "      <td>-0.006755</td>\n",
+              "      <td>0.974980</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "            mean  count      diff      risk\n",
+              "gender                                     \n",
+              "female  0.276824   2796  0.006856  1.025396\n",
+              "male    0.263214   2838 -0.006755  0.974980"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "seniorcitizen\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>seniorcitizen</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>0.242270</td>\n",
+              "      <td>4722</td>\n",
+              "      <td>-0.027698</td>\n",
+              "      <td>0.897403</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>0.413377</td>\n",
+              "      <td>912</td>\n",
+              "      <td>0.143409</td>\n",
+              "      <td>1.531208</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                   mean  count      diff      risk\n",
+              "seniorcitizen                                     \n",
+              "0              0.242270   4722 -0.027698  0.897403\n",
+              "1              0.413377    912  0.143409  1.531208"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "partner\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>partner</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>no</th>\n",
+              "      <td>0.329809</td>\n",
+              "      <td>2932</td>\n",
+              "      <td>0.059841</td>\n",
+              "      <td>1.221659</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>yes</th>\n",
+              "      <td>0.205033</td>\n",
+              "      <td>2702</td>\n",
+              "      <td>-0.064935</td>\n",
+              "      <td>0.759472</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "             mean  count      diff      risk\n",
+              "partner                                     \n",
+              "no       0.329809   2932  0.059841  1.221659\n",
+              "yes      0.205033   2702 -0.064935  0.759472"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "dependents\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>dependents</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>no</th>\n",
+              "      <td>0.313760</td>\n",
+              "      <td>3968</td>\n",
+              "      <td>0.043792</td>\n",
+              "      <td>1.162212</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>yes</th>\n",
+              "      <td>0.165666</td>\n",
+              "      <td>1666</td>\n",
+              "      <td>-0.104302</td>\n",
+              "      <td>0.613651</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                mean  count      diff      risk\n",
+              "dependents                                     \n",
+              "no          0.313760   3968  0.043792  1.162212\n",
+              "yes         0.165666   1666 -0.104302  0.613651"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "phoneservice\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>phoneservice</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>no</th>\n",
+              "      <td>0.241316</td>\n",
+              "      <td>547</td>\n",
+              "      <td>-0.028652</td>\n",
+              "      <td>0.893870</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>yes</th>\n",
+              "      <td>0.273049</td>\n",
+              "      <td>5087</td>\n",
+              "      <td>0.003081</td>\n",
+              "      <td>1.011412</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                  mean  count      diff      risk\n",
+              "phoneservice                                     \n",
+              "no            0.241316    547 -0.028652  0.893870\n",
+              "yes           0.273049   5087  0.003081  1.011412"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "multiplelines\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>multiplelines</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>no</th>\n",
+              "      <td>0.257407</td>\n",
+              "      <td>2700</td>\n",
+              "      <td>-0.012561</td>\n",
+              "      <td>0.953474</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>no_phone_service</th>\n",
+              "      <td>0.241316</td>\n",
+              "      <td>547</td>\n",
+              "      <td>-0.028652</td>\n",
+              "      <td>0.893870</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>yes</th>\n",
+              "      <td>0.290742</td>\n",
+              "      <td>2387</td>\n",
+              "      <td>0.020773</td>\n",
+              "      <td>1.076948</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                      mean  count      diff      risk\n",
+              "multiplelines                                        \n",
+              "no                0.257407   2700 -0.012561  0.953474\n",
+              "no_phone_service  0.241316    547 -0.028652  0.893870\n",
+              "yes               0.290742   2387  0.020773  1.076948"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "internetservice\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>internetservice</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>dsl</th>\n",
+              "      <td>0.192347</td>\n",
+              "      <td>1934</td>\n",
+              "      <td>-0.077621</td>\n",
+              "      <td>0.712482</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>fiber_optic</th>\n",
+              "      <td>0.425171</td>\n",
+              "      <td>2479</td>\n",
+              "      <td>0.155203</td>\n",
+              "      <td>1.574895</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>no</th>\n",
+              "      <td>0.077805</td>\n",
+              "      <td>1221</td>\n",
+              "      <td>-0.192163</td>\n",
+              "      <td>0.288201</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                     mean  count      diff      risk\n",
+              "internetservice                                     \n",
+              "dsl              0.192347   1934 -0.077621  0.712482\n",
+              "fiber_optic      0.425171   2479  0.155203  1.574895\n",
+              "no               0.077805   1221 -0.192163  0.288201"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "onlinesecurity\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>onlinesecurity</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>no</th>\n",
+              "      <td>0.420921</td>\n",
+              "      <td>2801</td>\n",
+              "      <td>0.150953</td>\n",
+              "      <td>1.559152</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>no_internet_service</th>\n",
+              "      <td>0.077805</td>\n",
+              "      <td>1221</td>\n",
+              "      <td>-0.192163</td>\n",
+              "      <td>0.288201</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>yes</th>\n",
+              "      <td>0.153226</td>\n",
+              "      <td>1612</td>\n",
+              "      <td>-0.116742</td>\n",
+              "      <td>0.567570</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                         mean  count      diff      risk\n",
+              "onlinesecurity                                          \n",
+              "no                   0.420921   2801  0.150953  1.559152\n",
+              "no_internet_service  0.077805   1221 -0.192163  0.288201\n",
+              "yes                  0.153226   1612 -0.116742  0.567570"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "onlinebackup\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>onlinebackup</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>no</th>\n",
+              "      <td>0.404323</td>\n",
+              "      <td>2498</td>\n",
+              "      <td>0.134355</td>\n",
+              "      <td>1.497672</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>no_internet_service</th>\n",
+              "      <td>0.077805</td>\n",
+              "      <td>1221</td>\n",
+              "      <td>-0.192163</td>\n",
+              "      <td>0.288201</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>yes</th>\n",
+              "      <td>0.217232</td>\n",
+              "      <td>1915</td>\n",
+              "      <td>-0.052736</td>\n",
+              "      <td>0.804660</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                         mean  count      diff      risk\n",
+              "onlinebackup                                            \n",
+              "no                   0.404323   2498  0.134355  1.497672\n",
+              "no_internet_service  0.077805   1221 -0.192163  0.288201\n",
+              "yes                  0.217232   1915 -0.052736  0.804660"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "deviceprotection\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>deviceprotection</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>no</th>\n",
+              "      <td>0.395875</td>\n",
+              "      <td>2473</td>\n",
+              "      <td>0.125907</td>\n",
+              "      <td>1.466379</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>no_internet_service</th>\n",
+              "      <td>0.077805</td>\n",
+              "      <td>1221</td>\n",
+              "      <td>-0.192163</td>\n",
+              "      <td>0.288201</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>yes</th>\n",
+              "      <td>0.230412</td>\n",
+              "      <td>1940</td>\n",
+              "      <td>-0.039556</td>\n",
+              "      <td>0.853480</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                         mean  count      diff      risk\n",
+              "deviceprotection                                        \n",
+              "no                   0.395875   2473  0.125907  1.466379\n",
+              "no_internet_service  0.077805   1221 -0.192163  0.288201\n",
+              "yes                  0.230412   1940 -0.039556  0.853480"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "techsupport\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>techsupport</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>no</th>\n",
+              "      <td>0.418914</td>\n",
+              "      <td>2781</td>\n",
+              "      <td>0.148946</td>\n",
+              "      <td>1.551717</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>no_internet_service</th>\n",
+              "      <td>0.077805</td>\n",
+              "      <td>1221</td>\n",
+              "      <td>-0.192163</td>\n",
+              "      <td>0.288201</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>yes</th>\n",
+              "      <td>0.159926</td>\n",
+              "      <td>1632</td>\n",
+              "      <td>-0.110042</td>\n",
+              "      <td>0.592390</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                         mean  count      diff      risk\n",
+              "techsupport                                             \n",
+              "no                   0.418914   2781  0.148946  1.551717\n",
+              "no_internet_service  0.077805   1221 -0.192163  0.288201\n",
+              "yes                  0.159926   1632 -0.110042  0.592390"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "streamingtv\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>streamingtv</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>no</th>\n",
+              "      <td>0.342832</td>\n",
+              "      <td>2246</td>\n",
+              "      <td>0.072864</td>\n",
+              "      <td>1.269897</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>no_internet_service</th>\n",
+              "      <td>0.077805</td>\n",
+              "      <td>1221</td>\n",
+              "      <td>-0.192163</td>\n",
+              "      <td>0.288201</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>yes</th>\n",
+              "      <td>0.302723</td>\n",
+              "      <td>2167</td>\n",
+              "      <td>0.032755</td>\n",
+              "      <td>1.121328</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                         mean  count      diff      risk\n",
+              "streamingtv                                             \n",
+              "no                   0.342832   2246  0.072864  1.269897\n",
+              "no_internet_service  0.077805   1221 -0.192163  0.288201\n",
+              "yes                  0.302723   2167  0.032755  1.121328"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "streamingmovies\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>streamingmovies</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>no</th>\n",
+              "      <td>0.338906</td>\n",
+              "      <td>2213</td>\n",
+              "      <td>0.068938</td>\n",
+              "      <td>1.255358</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>no_internet_service</th>\n",
+              "      <td>0.077805</td>\n",
+              "      <td>1221</td>\n",
+              "      <td>-0.192163</td>\n",
+              "      <td>0.288201</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>yes</th>\n",
+              "      <td>0.307273</td>\n",
+              "      <td>2200</td>\n",
+              "      <td>0.037305</td>\n",
+              "      <td>1.138182</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                         mean  count      diff      risk\n",
+              "streamingmovies                                         \n",
+              "no                   0.338906   2213  0.068938  1.255358\n",
+              "no_internet_service  0.077805   1221 -0.192163  0.288201\n",
+              "yes                  0.307273   2200  0.037305  1.138182"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "contract\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>contract</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>month-to-month</th>\n",
+              "      <td>0.431701</td>\n",
+              "      <td>3104</td>\n",
+              "      <td>0.161733</td>\n",
+              "      <td>1.599082</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>one_year</th>\n",
+              "      <td>0.120573</td>\n",
+              "      <td>1186</td>\n",
+              "      <td>-0.149395</td>\n",
+              "      <td>0.446621</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>two_year</th>\n",
+              "      <td>0.028274</td>\n",
+              "      <td>1344</td>\n",
+              "      <td>-0.241694</td>\n",
+              "      <td>0.104730</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                    mean  count      diff      risk\n",
+              "contract                                           \n",
+              "month-to-month  0.431701   3104  0.161733  1.599082\n",
+              "one_year        0.120573   1186 -0.149395  0.446621\n",
+              "two_year        0.028274   1344 -0.241694  0.104730"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "paperlessbilling\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>paperlessbilling</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>no</th>\n",
+              "      <td>0.172071</td>\n",
+              "      <td>2313</td>\n",
+              "      <td>-0.097897</td>\n",
+              "      <td>0.637375</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>yes</th>\n",
+              "      <td>0.338151</td>\n",
+              "      <td>3321</td>\n",
+              "      <td>0.068183</td>\n",
+              "      <td>1.252560</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                      mean  count      diff      risk\n",
+              "paperlessbilling                                     \n",
+              "no                0.172071   2313 -0.097897  0.637375\n",
+              "yes               0.338151   3321  0.068183  1.252560"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "paymentmethod\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>mean</th>\n",
+              "      <th>count</th>\n",
+              "      <th>diff</th>\n",
+              "      <th>risk</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>paymentmethod</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>bank_transfer_(automatic)</th>\n",
+              "      <td>0.168171</td>\n",
+              "      <td>1219</td>\n",
+              "      <td>-0.101797</td>\n",
+              "      <td>0.622928</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>credit_card_(automatic)</th>\n",
+              "      <td>0.164339</td>\n",
+              "      <td>1217</td>\n",
+              "      <td>-0.105630</td>\n",
+              "      <td>0.608733</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>electronic_check</th>\n",
+              "      <td>0.455890</td>\n",
+              "      <td>1893</td>\n",
+              "      <td>0.185922</td>\n",
+              "      <td>1.688682</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>mailed_check</th>\n",
+              "      <td>0.193870</td>\n",
+              "      <td>1305</td>\n",
+              "      <td>-0.076098</td>\n",
+              "      <td>0.718121</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                               mean  count      diff      risk\n",
+              "paymentmethod                                                 \n",
+              "bank_transfer_(automatic)  0.168171   1219 -0.101797  0.622928\n",
+              "credit_card_(automatic)    0.164339   1217 -0.105630  0.608733\n",
+              "electronic_check           0.455890   1893  0.185922  1.688682\n",
+              "mailed_check               0.193870   1305 -0.076098  0.718121"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "for c in categorical:\n",
+        "    print(c)\n",
+        "    df_group = df_full_train.groupby(c).churn.agg(['mean', 'count'])\n",
+        "    df_group['diff'] = df_group['mean'] - global_churn\n",
+        "    df_group['risk'] = df_group['mean'] / global_churn\n",
+        "    display(df_group)\n",
+        "    print()\n",
+        "    print()"
+      ],
+      "id": "uITS8r8_F5z5"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kgYTii3LF5z5"
+      },
+      "source": [
+        "## 3.6 Feature importance: Mutual information\n",
+        "\n",
+        "Mutual information - concept from information theory, it tells us how much\n",
+        "we can learn about one variable if we know the value of another\n",
+        "\n",
+        "* https://en.wikipedia.org/wiki/Mutual_information"
+      ],
+      "id": "kgYTii3LF5z5"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "T-6TkySUF5z5"
+      },
+      "outputs": [],
+      "source": [
+        "from sklearn.metrics import mutual_info_score"
+      ],
+      "id": "T-6TkySUF5z5"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "h5FR-9bNF5z5",
+        "outputId": "681191bf-6e79-4783-ed81-9055d9a51eae"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.0983203874041556"
+            ]
+          },
+          "execution_count": 40,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "mutual_info_score(df_full_train.churn, df_full_train.contract)"
+      ],
+      "id": "h5FR-9bNF5z5"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "M1tWd9YTF5z5",
+        "outputId": "109a68a8-b688-4bc2-b563-2d4965b831ac"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.0001174846211139946"
+            ]
+          },
+          "execution_count": 41,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "mutual_info_score(df_full_train.gender, df_full_train.churn)"
+      ],
+      "id": "M1tWd9YTF5z5"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "MRqJRUfeF5z6",
+        "outputId": "146128c4-f48c-4b7f-8526-7883ff645406"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.0983203874041556"
+            ]
+          },
+          "execution_count": 42,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "mutual_info_score(df_full_train.contract, df_full_train.churn)"
+      ],
+      "id": "MRqJRUfeF5z6"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "WgH0feKeF5z6",
+        "outputId": "4cf93382-2a33-4557-ebc9-f83bc890be40"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.009967689095399745"
+            ]
+          },
+          "execution_count": 43,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "mutual_info_score(df_full_train.partner, df_full_train.churn)"
+      ],
+      "id": "WgH0feKeF5z6"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "0iCZbBCyF5z6"
+      },
+      "outputs": [],
+      "source": [
+        "def mutual_info_churn_score(series):\n",
+        "    return mutual_info_score(series, df_full_train.churn)"
+      ],
+      "id": "0iCZbBCyF5z6"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "4hV9zJHdF5z6",
+        "outputId": "473fbaac-5e11-4391-fe4c-6ad7e78bcfd2"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "contract            0.098320\n",
+              "onlinesecurity      0.063085\n",
+              "techsupport         0.061032\n",
+              "internetservice     0.055868\n",
+              "onlinebackup        0.046923\n",
+              "deviceprotection    0.043453\n",
+              "paymentmethod       0.043210\n",
+              "streamingtv         0.031853\n",
+              "streamingmovies     0.031581\n",
+              "paperlessbilling    0.017589\n",
+              "dependents          0.012346\n",
+              "partner             0.009968\n",
+              "seniorcitizen       0.009410\n",
+              "multiplelines       0.000857\n",
+              "phoneservice        0.000229\n",
+              "gender              0.000117\n",
+              "dtype: float64"
+            ]
+          },
+          "execution_count": 45,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "mi = df_full_train[categorical].apply(mutual_info_churn_score)\n",
+        "mi.sort_values(ascending=False)"
+      ],
+      "id": "4hV9zJHdF5z6"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_II5XPncF5z7"
+      },
+      "source": [
+        "## 3.7 Feature importance: Correlation\n",
+        "\n",
+        "How about numerical columns?\n",
+        "\n",
+        "* Correlation coefficient - https://en.wikipedia.org/wiki/Pearson_correlation_coefficient"
+      ],
+      "id": "_II5XPncF5z7"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "szYa12OrF5z7",
+        "outputId": "02c22240-3c86-47b6-916b-57b80b9cc18c"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "72"
+            ]
+          },
+          "execution_count": 46,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_full_train.tenure.max()"
+      ],
+      "id": "szYa12OrF5z7"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "VRFxsNlqF5z7",
+        "outputId": "77d9d53a-d6fa-4257-a846-69f5689eed63"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "tenure            0.351885\n",
+              "monthlycharges    0.196805\n",
+              "totalcharges      0.196353\n",
+              "dtype: float64"
+            ]
+          },
+          "execution_count": 47,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_full_train[numerical].corrwith(df_full_train.churn).abs()"
+      ],
+      "id": "VRFxsNlqF5z7"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "dYSE3QVHF5z7",
+        "outputId": "605b7130-4078-4ad3-b568-142ee6a64851"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.5953420669577875"
+            ]
+          },
+          "execution_count": 48,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_full_train[df_full_train.tenure <= 2].churn.mean()"
+      ],
+      "id": "dYSE3QVHF5z7"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3A_cFpMjF5z7",
+        "outputId": "4f5027aa-c9e0-4e7d-832c-ea07ebd20020"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.3994413407821229"
+            ]
+          },
+          "execution_count": 49,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_full_train[(df_full_train.tenure > 2) & (df_full_train.tenure <= 12)].churn.mean()"
+      ],
+      "id": "3A_cFpMjF5z7"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "JNkcee_wF5z7",
+        "outputId": "afc37842-2c69-404d-8336-72d5821d3eab"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.17634908339788277"
+            ]
+          },
+          "execution_count": 50,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_full_train[df_full_train.tenure > 12].churn.mean()"
+      ],
+      "id": "JNkcee_wF5z7"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "5lHzV-IuF5z8",
+        "outputId": "1fedde2c-7653-40f5-97a8-88ebee8b788c"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.08795411089866156"
+            ]
+          },
+          "execution_count": 51,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_full_train[df_full_train.monthlycharges <= 20].churn.mean()"
+      ],
+      "id": "5lHzV-IuF5z8"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "LiIVsSTFF5z8",
+        "outputId": "cf5e99d8-29fe-4f1d-8593-f3218a30f8d6"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.18340943683409436"
+            ]
+          },
+          "execution_count": 52,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_full_train[(df_full_train.monthlycharges > 20) & (df_full_train.monthlycharges <= 50)].churn.mean()"
+      ],
+      "id": "LiIVsSTFF5z8"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "cqz5mWYuF5z8",
+        "outputId": "16d049f5-c7af-4e11-c7b4-d54d471fbc01"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.32499341585462205"
+            ]
+          },
+          "execution_count": 53,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_full_train[df_full_train.monthlycharges > 50].churn.mean()"
+      ],
+      "id": "cqz5mWYuF5z8"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_pBTOxTdF5z8"
+      },
+      "source": [
+        "## 3.8 One-hot encoding\n",
+        "\n",
+        "* Use Scikit-Learn to encode categorical features"
+      ],
+      "id": "_pBTOxTdF5z8"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "mK5huyqxF5z8"
+      },
+      "outputs": [],
+      "source": [
+        "from sklearn.feature_extraction import DictVectorizer"
+      ],
+      "id": "mK5huyqxF5z8"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "_oCUwF06F5z9"
+      },
+      "outputs": [],
+      "source": [
+        "dv = DictVectorizer(sparse=False)\n",
+        "\n",
+        "train_dict = df_train[categorical + numerical].to_dict(orient='records')\n",
+        "X_train = dv.fit_transform(train_dict)\n",
+        "\n",
+        "val_dict = df_val[categorical + numerical].to_dict(orient='records')\n",
+        "X_val = dv.transform(val_dict)"
+      ],
+      "id": "_oCUwF06F5z9"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gErgDUQXF5z9"
+      },
+      "source": [
+        "## 3.9 Logistic regression\n",
+        "\n",
+        "* Binary classification\n",
+        "* Linear vs logistic regression"
+      ],
+      "id": "gErgDUQXF5z9"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "rv6qy9TBF5z9"
+      },
+      "outputs": [],
+      "source": [
+        "def sigmoid(z):\n",
+        "    return 1 / (1 + np.exp(-z))"
+      ],
+      "id": "rv6qy9TBF5z9"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "O7t5T1yzF5z9"
+      },
+      "outputs": [],
+      "source": [
+        "z = np.linspace(-7, 7, 51)"
+      ],
+      "id": "O7t5T1yzF5z9"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "mbwXdEmgF5z9",
+        "outputId": "deb29c0c-7a8a-4d94-c479-4cc3f879549c"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "1.0"
+            ]
+          },
+          "execution_count": 58,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "sigmoid(10000)"
+      ],
+      "id": "mbwXdEmgF5z9"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "E26MZvAoF5z-",
+        "outputId": "b329fa58-edb3-4433-cd98-a95fe9e5e256"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "[<matplotlib.lines.Line2D at 0x7f342d0bf080>]"
+            ]
+          },
+          "execution_count": 59,
+          "metadata": {},
+          "output_type": "execute_result"
+        },
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD4CAYAAAD8Zh1EAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAfs0lEQVR4nO3deXiV9Z3+8ffnnKwkJAESEQiQREBBpIqA1AUX1LpVO9qp0Naxaks7rR07OouOM9bpXO1Y21+ntuO04lqtVRmrlam41KUiIgoubLIlYQtbwhZIyHrO5/dHoo0QyFFOeM5yv67rXOc85zxJbiC5+eZ7nuf5mrsjIiLJLxR0ABERiQ8VuohIilChi4ikCBW6iEiKUKGLiKSIjKC+cHFxsZeVlQX15UVEktI777yz3d1LunstsEIvKytj0aJFQX15EZGkZGbrD/aaplxERFKECl1EJEWo0EVEUoQKXUQkRajQRURSRI+FbmYPmFmtmS07yOtmZr8ws0ozW2Jm4+MfU0REehLLCP0h4IJDvH4hMLLzNgP41eHHEhGRT6rH49Ddfa6ZlR1il8uAh73jOrwLzKzIzAa5+5Y4ZRQR6RXuTmskSmt7lJb2jvvW9ihtkShtEe+8j9IaidIecSLRjuciUac9+pftqHdsRzufizhEolGiDlHveL7r46mjB/KZoUVx//PE48SiIcDGLts1nc8dUOhmNoOOUTzDhg2Lw5cWkXTi7uxrjVDf1HbAbW9zOw3N7TS2ttPQ0k5j521fa4SmtghNrRGa27o87izvIBxVkJOwhW7dPNftqhnuPhOYCTBhwgStrCEiQEdR72hsZcvuZjbtbmLz7iZq97awo6GF7Q0tbG9o7Xjc2NpjCWdnhMjPziDvw1tWmPzsDIrzs8nNDHfcssJkZ4bIzgiTnREiOyNEVpf7zHCIjFCIrAz76HFm2MgIh8gIGRlhIyNkhEMd26FQx3bIjHCo4xYyOu//8nzIwKy7yoyPeBR6DTC0y3YpsDkOn1dEUkg06myub6K6rpHqugaqtzeydnsjNbs6Crxlv6LODBsD8rIp7pvFgLxsRg3sS3HfLPr1yaIwN5Oi3EwKczMp+PA+J5O87DAZ4fQ9eC8ehT4buN7MHgdOAeo1fy6S3prbIqzYsodlm+pZUlPP8s17qN7eQHPbX0o7PzuDipI8xgwu4LwxAxlcmMOgolyGFOUyqDCH/nlZvTqaTUU9FrqZPQacBRSbWQ3wfSATwN1/DcwBLgIqgX3ANb0VVkQS07Y9zcyv2s6Cqp0srtnNmtoGItGOWdV+fTIZO6SQzx4znIqSPCqK8zmmJI+Svtkq7DiL5SiX6T287sB34pZIRBLe7n2tLKjewRuVO5hftZ2qukYAivpk8pnSIs4dPZCxQwo5obSQwYU5Ku4jJLDL54pIctnR0MLzy7fy7JItLKjeQdShT1aYSeX9mTZxGJ89ZgBjBhUQCqm8g6JCF5GD2tXYygvLt/Ls0i3Mr9pBJOpUFOfxnbNHcOaoEsaVFpGVkb5vQiYaFbqIHODdDbt48I11PLd0C+1RZ/iAPnzrzAouPmEwowf11RRKglKhiwgAbZEozy3bygPz1vL+xt30zc7gbz5bxuXjh3D84AKVeBJQoYukuT3NbTzy5noeeXM9W/c0UzagD/9+6fFccXIp+dmqiGSify2RNNUWifLY2xv4+Utr2NnYyukjivnhX43l7GOP0hubSUqFLpJm3J2XV9Tyo+dWUF3XyOSK/tx60RhOKC0MOpocJhW6SBpZtqmeHz67gjerd1BRkse9fzOBc0cfpfnxFKFCF0kDzW0R7nhuJb95cx39+mTxg8uOZ/qkYWSm8XVPUpEKXSTFLd9cz/cef581tQ187dQybjx/FAU5mUHHkl6gQhdJUdGoc9+8an7ywir69cni4WsnMWVUSdCxpBep0EVS0Jb6Jm6atZj5VTv43PED+c/Lx9E/LyvoWNLLVOgiKeblFdu4cdZiWtuj3HH5CVw5caje9EwTKnSRFPLIgvV8/5lljBlcwC+nj6e8OC/oSHIEqdBFUoC789MXV3H3q1Wcc9xR/PeXT6JPln68043+xUWSXGt7lJufWsJT725i+qSh/MdlY9N6GbZ0pkIXSWINLe387W/f4fU127nxvFF895wRmi9PYyp0kSRVu6eZrz24kFXb9nLnF8fxpQlDe/4gSWkqdJEktKOhhWn3LmBrfTP3Xz2Bs449KuhIkgBU6CJJpqGlnWseWsimXU08ct0pTCrvH3QkSRAqdJEk0toe5VuPvMPyzXu456snq8zlY/RWuEiSiEadG2e9z7zK7dxx+QmcO2Zg0JEkwajQRZKAu/Pv/7ecPy7Zwi0XHsdf6w1Q6YYKXSQJ/PKVSn7z5npmTKngm2ceE3QcSVAqdJEE97u3NvCzP63miyeXcsuFxwUdRxKYCl0kgb23YRe3PbOMs48t4Y7LT9BJQ3JIKnSRBLV7XyvX/+49ji7M4edXnqTT+aVHOmxRJAFFo85NsxZTu7eZJ791KoV9tMKQ9Ez/5YskoHtfr+bllbXcetFoPjO0KOg4kiRU6CIJZtG6ndz5wiouOuForj61LOg4kkRU6CIJZGdjx7x5ab9c7rhinN4ElU8kpkI3swvMbJWZVZrZzd28PszMXjWz98xsiZldFP+oIqktGnX+/on32bmvlbu/PJ6CHM2byyfTY6GbWRi4G7gQGANMN7Mx++32r8Asdz8JmAb8T7yDiqS6X8+t4rXVddx2yRjGDikMOo4koVhG6JOASnevdvdW4HHgsv32caCg83EhsDl+EUVS36qte/nZi6u5eNwgvnLKsKDjSJKKpdCHABu7bNd0PtfV7cBXzawGmAN8t7tPZGYzzGyRmS2qq6v7FHFFUk8k6tz81BIKcjP5j8vGat5cPrVYCr277y7fb3s68JC7lwIXAY+Y2QGf291nuvsEd59QUlLyydOKpKDfLljPext2c9slY+iflxV0HElisRR6DdD10m6lHDilch0wC8Dd3wRygOJ4BBRJZZt3N3Hn8yuZMqqEy04cHHQcSXKxFPpCYKSZlZtZFh1ves7eb58NwFQAMxtNR6FrTkXkENydf/vDMqIOP/yCplrk8PVY6O7eDlwPvACsoONoluVm9gMzu7Rzt5uAb5jZYuAx4Gvuvv+0jIh08ezSLby8spabzh/F0P59go4jKSCma7m4+xw63uzs+txtXR5/AJwW32giqWv3vlZun72ccaWFXHNaedBxJEXo4lwiAfjRnBXs2tfGw9eeQjikqRaJD536L3KEza/azqxFNXzjjArGDC7o+QNEYqRCFzmCWtuj3Pr0MoYP6MP3zh0ZdBxJMZpyETmCfrtgPWu3N/LgNRPJyQwHHUdSjEboIkdIfVMbv3hlDWeMLOasUTqxTuJPhS5yhPzPq5XUN7Vxy4Wjdcy59AoVusgRsHHnPh58Yx1XjC/VG6HSa1ToIkfAT19cRSgEN50/KugoksJU6CK9bPHG3Tzz/ma+fnoFgwpzg44jKUyFLtKL3J0fzllBcX4W3zrrmKDjSIpToYv0oj99sI231+7ke+eOIj9bRwlL71Khi/SStkiUO55fyTEleUybOLTnDxA5TCp0kV7y+NsbqK5r5JYLR5MR1o+a9D59l4n0gsaWdn7+0homV/Rn6uijgo4jaUKTeiK94JEF69nR2Mq9Fxynk4jkiNEIXSTO9rW2c+/caqaMKmH8sH5Bx5E0okIXibPfdo7Ob5g6IugokmZU6CJx1NQaYebcak4fUczJw/sHHUfSjApdJI4efWs92xtauUHXOpcAqNBF4qSpNcKvX6vm1GMGMLFMo3M58lToInHyu7c3sL2hhRumanQuwVChi8RBc1uEX79WxeSK/pxSMSDoOJKmVOgicfD42xuo29vCDVN1eVwJjgpd5DA1t0X41WtVTCrrz+QKzZ1LcFToIodp1qKNbNvTwg3njtRZoRIoFbrIYWhpj/CrP1cxYXg/Tj1Gc+cSLBW6yGF45r3NbKlv5rtTNTqX4KnQRT6laNSZ+Xo1owcVMGVkcdBxRFToIp/WKytrqaxt4JtTKjQ6l4SgQhf5lO6ZW8WQolwuHjco6CgiQIyFbmYXmNkqM6s0s5sPss+XzOwDM1tuZr+Lb0yRxPLO+l0sXLeL604vJ1OrEUmC6HGBCzMLA3cD5wE1wEIzm+3uH3TZZyRwC3Cau+8yMy3RIilt5twqCnMzuVJrhUoCiWVoMQmodPdqd28FHgcu22+fbwB3u/suAHevjW9MkcRRXdfAix9s46rJw8nL1qJfkjhiKfQhwMYu2zWdz3U1ChhlZm+Y2QIzu6C7T2RmM8xskZktqqur+3SJRQJ27+tryQyHuPrUsqCjiHxMLIXe3dv3vt92BjASOAuYDtxnZkUHfJD7THef4O4TSkpKPmlWkcDV7W3h9+/WcMX4Ukr6ZgcdR+RjYin0GqDrRGEpsLmbfZ5x9zZ3XwusoqPgRVLKb+avoy0S5RtnlAcdReQAsRT6QmCkmZWbWRYwDZi93z5/AM4GMLNiOqZgquMZVCRojS3tPLJgPZ8bczQVJflBxxE5QI+F7u7twPXAC8AKYJa7LzezH5jZpZ27vQDsMLMPgFeBf3T3Hb0VWiQITyzcSH1TGzPOrAg6iki3YnqL3t3nAHP2e+62Lo8duLHzJpJy2iJR7p+3lkll/Rk/rF/QcUS6pTMiRGLw3LKtbNrdxIwpGp1L4lKhi/TA3bn/9WoqivM45zidMyeJS4Uu0oN31u9icU0915xWRiiki3BJ4lKhi/Tg/nlrKczN5IqTS4OOInJIKnSRQ9i4cx8vLN/Kl08ZRp8sneYviU2FLnIID81fR8iMqz9bFnQUkR6p0EUOYm9zG08s3MjF4wZxdGFO0HFEeqRCFzmIJxZupKGlnetO12n+khxU6CLdiESdh+avY2JZP8aVHnCdOZGEpEIX6caLy7dSs6tJo3NJKip0kW7cP28tQ/vnct6Yo4OOIhIzFbrIfhZv3M2i9bu45tRywjqRSJKICl1kP/fPW0vf7Ay+pPVCJcmo0EW62FLfxLNLt3DlxKHka71QSTIqdJEuHpq/DnfXeqGSlFToIp0aW9p57K0NXDD2aIb27xN0HJFPTIUu0un379awp7md607XNc8lOanQRYBo1HnwjXWcOLSIk4drRSJJTip0EeCVlbWs3d6oE4kkqanQRYD75lUzuDCHC8fqRCJJXip0SXvLN9ezoHonV59aRkZYPxKSvPTdK2nv/nlr6ZMVZtqkYUFHETksKnRJa7V7mvm/xZv50oShFOZmBh1H5LCo0CWtPbJgPe1R55rTyoKOInLYVOiStprbIvx2wXrOHT2Q4QPygo4jcthU6JK2nnp3E7v2telQRUkZKnRJS+7OA2+s5fjBBZxS3j/oOCJxoUKXtPTa6joqaxu47vRyzHTNc0kNKnRJSzPnVjOwIJtLxg0OOopI3KjQJe0sralnftUOrju9nKwM/QhI6tB3s6Sde+ZW0Tc7g+k6kUhSTEyFbmYXmNkqM6s0s5sPsd8XzczNbEL8IorEz4Yd+5izdAtfnjyMvjk6kUhSS4+FbmZh4G7gQmAMMN3MxnSzX1/g74C34h1SJF7um1dNOGRce5oOVZTUE8sIfRJQ6e7V7t4KPA5c1s1+/wHcCTTHMZ9I3OxsbGXWoo184cQhDCzICTqOSNzFUuhDgI1dtms6n/uImZ0EDHX3Px7qE5nZDDNbZGaL6urqPnFYkcPx8JvraG6LMmOKViSS1BRLoXd3kK5/9KJZCPgv4KaePpG7z3T3Ce4+oaSkJPaUIoepqTXCw2+uZ+pxRzFyYN+g44j0ilgKvQYY2mW7FNjcZbsvMBb4s5mtAyYDs/XGqCSSJ9/ZyM7GVr555jFBRxHpNbEU+kJgpJmVm1kWMA2Y/eGL7l7v7sXuXubuZcAC4FJ3X9QriUU+oUjUuff1tZw0rIiJZVovVFJXj4Xu7u3A9cALwApglrsvN7MfmNmlvR1Q5HA9v2wrG3bu45tTKnSav6S0jFh2cvc5wJz9nrvtIPuedfixROLD3blnbhXlxXmcN0brhUpq05miktIWVO9kSU09Xz+jnHBIo3NJbSp0SWm/fGUNxfnZXDG+NOgoIr1OhS4pa+G6ncyv2sG3zqwgJzMcdByRXqdCl5R110trKM7P4iunDA86isgRoUKXlPTO+p3Mq9zOjCkV5GZpdC7pQYUuKemulysZkJfFVydrdC7pQ4UuKee9DbuYu7qOb0ypoE9WTEfmiqQEFbqknLteXkP/vCyu0uhc0owKXVLK+xt38+dVdXz9jHLysjU6l/SiQpeU8ouX11DUJ5O/+WxZ0FFEjjgVuqSMJTW7eWVlLV8/vZx8jc4lDanQJWX84uU1FOZmcvWpZUFHEQmECl1SwrJN9by0opbrTi/X4s+StlTokhJ+8sIqCnIy+NppZUFHEQmMCl2S3utr6nhtdR3XnzOCAo3OJY2p0CWpRaLOD59dQWm/XB3ZImlPhS5J7al3a1i5dS//dMFxuqKipD0VuiStptYI/+/F1XxmaBGfHzco6DgigVOhS9K6f141W/c0c+tFo7VWqAgqdElSdXtb+NWfqzh/zEAmlfcPOo5IQlChS1K66+XVtLRHufnC44KOIpIwVOiSdCpr9/LY2xv5yinDqCjJDzqOSMJQoUvSueO5lfTJDPN3U0cGHUUkoajQJam8WbWDl1bU8u2zRzAgPzvoOCIJRYUuSaO1Pcrts5czpCiXa3SKv8gBdI1RSRoz51axatte7r96gk4iEumGRuiSFKrqGvjFy5VcPG4QU0cPDDqOSEJSoUvCi0adW55aSk5miO9/fkzQcUQSlgpdEt4Tizby9tqd3HrxaI7qmxN0HJGEpUKXhFa7p5kfzVnB5Ir+fGnC0KDjiCS0mArdzC4ws1VmVmlmN3fz+o1m9oGZLTGzl81sePyjSjr6/uzltLRH+c/Lx+l6LSI96LHQzSwM3A1cCIwBppvZ/hOZ7wET3H0c8CRwZ7yDSvp5cflWnlu2lRumjqS8OC/oOCIJL5YR+iSg0t2r3b0VeBy4rOsO7v6qu+/r3FwAlMY3pqSbPc1t/Nszyzju6L7MmFIRdByRpBBLoQ8BNnbZrul87mCuA57r7gUzm2Fmi8xsUV1dXewpJe3855yV1O5t4Y4rxpEZ1ls9IrGI5Selu4lL73ZHs68CE4CfdPe6u8909wnuPqGkpCT2lJJW/m/xZh57ewMzzqjgxKFFQccRSRqxnClaA3Q9vKAU2Lz/TmZ2LnArcKa7t8QnnqSb6roGbv79Ek4e3o9/+NyxQccRSSqxjNAXAiPNrNzMsoBpwOyuO5jZScA9wKXuXhv/mJIOmtsifPvRd8nKCPHL6SdpqkXkE+rxJ8bd24HrgReAFcAsd19uZj8ws0s7d/sJkA/8r5m9b2azD/LpRA7q9tnLWbl1Lz+78kQGF+UGHUck6cR0cS53nwPM2e+527o8PjfOuSTNPP1eDY8v3Mi3zzqGs489Kug4IklJv9NK4Cpr9/IvTy1jUnl/bjxvVNBxRJKWCl0Cta+1nW8/+i59ssL8cvpJZGjeXORT0/XQJTDuzq1PL2NNbQOPXHsKAwt04S2Rw6HhkATmjudX8vR7m7jpvFGcPrI46DgiSU+FLoGYObeKe16r5qrJw/nO2SOCjiOSElTocsQ9+U4NP5qzkovHDeL2S4/XVRRF4kSFLkfUSx9s459/v4TTRxTzsy99hnBIZS4SLyp0OWIWrtvJd373LscPLuDXV51MdoYWehaJJxW6HBErtuzh2ocWMqQolwe/NpH8bB1gJRJvKnTpdUtqdnPV/W/RJyvMw9dNYkB+dtCRRFKSCl161aurapk2cwHZGWEe/fpkSvv1CTqSSMrS773Sa2Yt3MgtTy/l2IF9eeiaiRylE4dEepUKXeLO3bnr5TX8/KU1nDGymP/5ynj65mQGHUsk5anQJa7aI1H+9Q/LeHzhRi4fP4Qfawk5kSNGhS5xs7Oxlb9/4n1eW13H9WeP4KbzR+mkIZEjSIUucfHa6jr+4X8Xs3tfKz/8q7F85ZThQUcSSTsqdDkszW0Rfvz8Sh58Yx0jj8rnN9dMYszggqBjiaQlFbp8aiu37uGGx95n1ba9fO3UMm6+8DhyMnX2p0hQVOjyibVHojw0fx13Pr+KgtxMHrxmopaNE0kAKnSJmbvz6qpafjRnJZW1DZw7eiA/vuIEnfkpkiBU6BKT5Zvr+dGcFbxRuYPy4jzuuepkzh8zUEexiCQQFboc0tb6Zn764ip+/24NRbmZ3P75MXxl8nAdWy6SgFTo0q3V2/by4BvrePq9GqJR+MYZFXzn7BEU5uqMT5FEpUKXj0Sjzmur63jgjbW8vmY72RkhvnDiEK4/ZwRD++uiWiKJToUu7GpsZfbizfxm/jqqtzcysCCbf/zcsUyfNIz+eVlBxxORGKnQ01T9vjZeWL6VPy7dwhuV24lEnROHFnHXtBO56IRBmiMXSUIq9DRSt7eF11bX8eySzcyr3E5bxBnWvw8zplRwybhBHD+4MOiIInIYVOgprL6pjbeqdzC/agfzq7azelsDAEOKcrn2tHIuGTeYsUMKdOihSIpQoaeI9kiUqrpGlm6qZ9mmet7bsIulm+qJOuRkhphY1p+/OqmU00cUq8RFUpQKPcm4O7V7W6iqa6C6rpE12/aydFM9H2zZQ3NbFIA+WWHGDi7k+nNGctoxAzhxWBHZGbrGikiqU6EnoMaWdrbUN7FpdzObdzexeXcTG3buo7qukbXbG2loaf9o3z5ZYY4fXMD0ScM4YUgh40oLKS/OJxzSCFwk3cRU6GZ2AXAXEAbuc/c79ns9G3gYOBnYAVzp7uviGzU5uTvNbVHqm9o+uu3e18qufa1sb2hle0MLO7rcb9vbzO59bR/7HCGDQYW5VJTkccX4IVSU5FNRkkdFST6DCnIIqbxFhBgK3czCwN3AeUANsNDMZrv7B112uw7Y5e4jzGwa8GPgyt4IfDiiUac96kSiTns0SnvEaYtGaYs47ZEobZGOx22RKK3tUVraP7yP0NK53dIWoaktQlNrlKa2CM1tEZpaIzS2ttPY0k5jS4SGlvaPtvc0tdMaiR40U352BgPysyjOz2b4gD5MLO/H4KJchhTlMrjzNrBvNhk6jFBEehDLCH0SUOnu1QBm9jhwGdC10C8Dbu98/CTw32Zm7u5xzArAEws3MHNuNe4QcSfqTjRKx713lPWHt6hDezRKNNp5H+c0WeEQOZkhcjLD5GdnkJedQV52mMFFOZ2PM+ibk0FhbiaFuZkU5Wb95XGfTIrzs8nN0ty2iMRHLIU+BNjYZbsGOOVg+7h7u5nVAwOA7V13MrMZwAyAYcOGfarA/fOyOW5QASEzQgZhM6zzcciMcNgImxEO/eUWMiMz3PE4I2RkhENkdL6WGQ6RGf7wPvTRdlZGiOyMcOd9iKyMEFnhELlZYXIzw+RkhjVPLSIJJZZC76619h/rxrIP7j4TmAkwYcKETzVePm/MQM4bM/DTfKiISEqLZWK2BhjaZbsU2HywfcwsAygEdsYjoIiIxCaWQl8IjDSzcjPLAqYBs/fbZzZwdefjLwKv9Mb8uYiIHFyPUy6dc+LXAy/QcdjiA+6+3Mx+ACxy99nA/cAjZlZJx8h8Wm+GFhGRA8V0HLq7zwHm7PfcbV0eNwN/Hd9oIiLySejgZhGRFKFCFxFJESp0EZEUoUIXEUkRFtTRhWZWB6wP5IsfXDH7nd2a4JIpr7L2nmTKm0xZITHzDnf3ku5eCKzQE5GZLXL3CUHniFUy5VXW3pNMeZMpKyRfXk25iIikCBW6iEiKUKF/3MygA3xCyZRXWXtPMuVNpqyQZHk1hy4ikiI0QhcRSREqdBGRFKFC74aZfdfMVpnZcjO7M+g8PTGzfzAzN7PioLMcipn9xMxWmtkSM3vazIqCzrQ/M7ug89++0sxuDjrPoZjZUDN71cxWdH6v3hB0pp6YWdjM3jOzPwad5VDMrMjMnuz8fl1hZp8NOlMsVOj7MbOz6VgjdZy7Hw/8NOBIh2RmQ+lYwHtD0Fli8CdgrLuPA1YDtwSc52O6LIh+ITAGmG5mY4JNdUjtwE3uPhqYDHwnwfMC3ACsCDpEDO4Cnnf344DPkByZVejd+FvgDndvAXD32oDz9OS/gH+imyX/Eo27v+ju7Z2bC+hY/SqRfLQguru3Ah8uiJ6Q3H2Lu7/b+XgvHaUzJNhUB2dmpcDFwH1BZzkUMysAptCxzgPu3uruu4NNFRsV+oFGAWeY2Vtm9pqZTQw60MGY2aXAJndfHHSWT+Fa4LmgQ+ynuwXRE7YguzKzMuAk4K1gkxzSz+kYfESDDtKDCqAOeLBzeug+M8sLOlQsYlrgItWY2UvA0d28dCsdfyf96PgVdiIwy8wqglpSr4es/wKcf2QTHdqh8rr7M5373ErHdMGjRzJbDGJa7DzRmFk+8Hvge+6+J+g83TGzS4Bad3/HzM4KOk8PMoDxwHfd/S0zuwu4Gfi3YGP1LC0L3d3PPdhrZva3wFOdBf62mUXpuEBP3ZHK19XBsprZCUA5sNjMoGP64l0zm+TuW49gxI851N8tgJldDVwCTE3AdWdjWRA9oZhZJh1l/qi7PxV0nkM4DbjUzC4CcoACM/utu3814FzdqQFq3P3D33aepKPQE56mXA70B+AcADMbBWSReFdbw92XuvtR7l7m7mV0fBOOD7LMe2JmFwD/DFzq7vuCztONWBZETxjW8T/5/cAKd/9Z0HkOxd1vcffSzu/VaXQsJJ+IZU7nz9BGMzu286mpwAcBRopZWo7Qe/AA8ICZLQNagasTcCSZrP4byAb+1PlbxQJ3/1awkf7iYAuiBxzrUE4DrgKWmtn7nc/9S+cawHJ4vgs82vkfezVwTcB5YqJT/0VEUoSmXEREUoQKXUQkRajQRURShApdRCRFqNBFRFKECl1EJEWo0EVEUsT/B5oxTW3I3ynjAAAAAElFTkSuQmCC\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          },
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "plt.plot(z, sigmoid(z))"
+      ],
+      "id": "E26MZvAoF5z-"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "tyTBC40bF5z-"
+      },
+      "outputs": [],
+      "source": [
+        "def linear_regression(xi):\n",
+        "    result = w0\n",
+        "\n",
+        "    for j in range(len(w)):\n",
+        "        result = result + xi[j] * w[j]\n",
+        "\n",
+        "    return result"
+      ],
+      "id": "tyTBC40bF5z-"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "vQO3rdGMF5z-"
+      },
+      "outputs": [],
+      "source": [
+        "def logistic_regression(xi):\n",
+        "    score = w0\n",
+        "\n",
+        "    for j in range(len(w)):\n",
+        "        score = score + xi[j] * w[j]\n",
+        "\n",
+        "    result = sigmoid(score)\n",
+        "    return result"
+      ],
+      "id": "vQO3rdGMF5z-"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WDabr6xdF5z-"
+      },
+      "source": [
+        "## 3.10 Training logistic regression with Scikit-Learn\n",
+        "\n",
+        "* Train a model with Scikit-Learn\n",
+        "* Apply it to the validation dataset\n",
+        "* Calculate the accuracy"
+      ],
+      "id": "WDabr6xdF5z-"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "u76Jjz-SF5z-"
+      },
+      "outputs": [],
+      "source": [
+        "from sklearn.linear_model import LogisticRegression"
+      ],
+      "id": "u76Jjz-SF5z-"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "5yDFQfz8F5z_",
+        "outputId": "faeb3367-e047-40bb-c661-1595098442a1"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "LogisticRegression(C=1.0, class_weight=None, dual=False, fit_intercept=True,\n",
+              "                   intercept_scaling=1, l1_ratio=None, max_iter=100,\n",
+              "                   multi_class='warn', n_jobs=None, penalty='l2',\n",
+              "                   random_state=None, solver='lbfgs', tol=0.0001, verbose=0,\n",
+              "                   warm_start=False)"
+            ]
+          },
+          "execution_count": 63,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "model = LogisticRegression(solver='lbfgs')\n",
+        "# solver='lbfgs' is the default solver in newer version of sklearn\n",
+        "# for older versions, you need to specify it explicitly\n",
+        "model.fit(X_train, y_train)"
+      ],
+      "id": "5yDFQfz8F5z_"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "5llMX8MQF5z_",
+        "outputId": "155e646d-94b9-454c-e26f-4b43d0af36a4"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "-0.10903395348323511"
+            ]
+          },
+          "execution_count": 64,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "model.intercept_[0]"
+      ],
+      "id": "5llMX8MQF5z_"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "LUE1u7vSF5z_",
+        "outputId": "fb9ef883-9f0f-4c0d-ac33-68fbd330427d"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "array([ 0.475, -0.175, -0.408, -0.03 , -0.078,  0.063, -0.089, -0.081,\n",
+              "       -0.034, -0.073, -0.335,  0.316, -0.089,  0.004, -0.258,  0.141,\n",
+              "        0.009,  0.063, -0.089, -0.081,  0.266, -0.089, -0.284, -0.231,\n",
+              "        0.124, -0.166,  0.058, -0.087, -0.032,  0.07 , -0.059,  0.141,\n",
+              "       -0.249,  0.215, -0.12 , -0.089,  0.102, -0.071, -0.089,  0.052,\n",
+              "        0.213, -0.089, -0.232, -0.07 ,  0.   ])"
+            ]
+          },
+          "execution_count": 65,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "model.coef_[0].round(3)"
+      ],
+      "id": "LUE1u7vSF5z_"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "y11b6AZBF5z_"
+      },
+      "outputs": [],
+      "source": [
+        "y_pred = model.predict_proba(X_val)[:, 1]"
+      ],
+      "id": "y11b6AZBF5z_"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "plxWqZsWF5z_"
+      },
+      "outputs": [],
+      "source": [
+        "churn_decision = (y_pred >= 0.5)"
+      ],
+      "id": "plxWqZsWF5z_"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "fGzXPaEdF5z_",
+        "outputId": "23f71e03-cd22-4cf3-8c7e-9eaf7430b1b7"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.8034066713981547"
+            ]
+          },
+          "execution_count": 68,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "(y_val == churn_decision).mean()"
+      ],
+      "id": "fGzXPaEdF5z_"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "rc2_-_RlF50A"
+      },
+      "outputs": [],
+      "source": [
+        "df_pred = pd.DataFrame()\n",
+        "df_pred['probability'] = y_pred\n",
+        "df_pred['prediction'] = churn_decision.astype(int)\n",
+        "df_pred['actual'] = y_val"
+      ],
+      "id": "rc2_-_RlF50A"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "l19R2Am5F50A"
+      },
+      "outputs": [],
+      "source": [
+        "df_pred['correct'] = df_pred.prediction == df_pred.actual"
+      ],
+      "id": "l19R2Am5F50A"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "QAiVwLdnF50A",
+        "outputId": "85003aa1-a382-4805-cab0-9cd517f03bef"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.8034066713981547"
+            ]
+          },
+          "execution_count": 71,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_pred.correct.mean()"
+      ],
+      "id": "QAiVwLdnF50A"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "b1xfUTcyF50A",
+        "outputId": "6db063a8-a2d3-4f49-8494-46ea4a06609d"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "array([0, 0, 0, ..., 0, 1, 1])"
+            ]
+          },
+          "execution_count": 72,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "churn_decision.astype(int)"
+      ],
+      "id": "b1xfUTcyF50A"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "GDafqrdFF50A"
+      },
+      "source": [
+        "## 3.11 Model interpretation\n",
+        "\n",
+        "* Look at the coefficients\n",
+        "* Train a smaller model with fewer features"
+      ],
+      "id": "GDafqrdFF50A"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "rdhckRoKF50B"
+      },
+      "outputs": [],
+      "source": [
+        "a = [1, 2, 3, 4]\n",
+        "b = 'abcd'"
+      ],
+      "id": "rdhckRoKF50B"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "BbyESQ0mF50B",
+        "outputId": "a8a89559-cb8b-404d-f088-40010b7a3909"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{1: 'a', 2: 'b', 3: 'c', 4: 'd'}"
+            ]
+          },
+          "execution_count": 74,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "dict(zip(a, b))"
+      ],
+      "id": "BbyESQ0mF50B"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "scrolled": true,
+        "id": "bOYwSz5FF50B",
+        "outputId": "a7b28d89-8918-4ee1-c200-fc236c6ccac8"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'contract=month-to-month': 0.475,\n",
+              " 'contract=one_year': -0.175,\n",
+              " 'contract=two_year': -0.408,\n",
+              " 'dependents=no': -0.03,\n",
+              " 'dependents=yes': -0.078,\n",
+              " 'deviceprotection=no': 0.063,\n",
+              " 'deviceprotection=no_internet_service': -0.089,\n",
+              " 'deviceprotection=yes': -0.081,\n",
+              " 'gender=female': -0.034,\n",
+              " 'gender=male': -0.073,\n",
+              " 'internetservice=dsl': -0.335,\n",
+              " 'internetservice=fiber_optic': 0.316,\n",
+              " 'internetservice=no': -0.089,\n",
+              " 'monthlycharges': 0.004,\n",
+              " 'multiplelines=no': -0.258,\n",
+              " 'multiplelines=no_phone_service': 0.141,\n",
+              " 'multiplelines=yes': 0.009,\n",
+              " 'onlinebackup=no': 0.063,\n",
+              " 'onlinebackup=no_internet_service': -0.089,\n",
+              " 'onlinebackup=yes': -0.081,\n",
+              " 'onlinesecurity=no': 0.266,\n",
+              " 'onlinesecurity=no_internet_service': -0.089,\n",
+              " 'onlinesecurity=yes': -0.284,\n",
+              " 'paperlessbilling=no': -0.231,\n",
+              " 'paperlessbilling=yes': 0.124,\n",
+              " 'partner=no': -0.166,\n",
+              " 'partner=yes': 0.058,\n",
+              " 'paymentmethod=bank_transfer_(automatic)': -0.087,\n",
+              " 'paymentmethod=credit_card_(automatic)': -0.032,\n",
+              " 'paymentmethod=electronic_check': 0.07,\n",
+              " 'paymentmethod=mailed_check': -0.059,\n",
+              " 'phoneservice=no': 0.141,\n",
+              " 'phoneservice=yes': -0.249,\n",
+              " 'seniorcitizen': 0.215,\n",
+              " 'streamingmovies=no': -0.12,\n",
+              " 'streamingmovies=no_internet_service': -0.089,\n",
+              " 'streamingmovies=yes': 0.102,\n",
+              " 'streamingtv=no': -0.071,\n",
+              " 'streamingtv=no_internet_service': -0.089,\n",
+              " 'streamingtv=yes': 0.052,\n",
+              " 'techsupport=no': 0.213,\n",
+              " 'techsupport=no_internet_service': -0.089,\n",
+              " 'techsupport=yes': -0.232,\n",
+              " 'tenure': -0.07,\n",
+              " 'totalcharges': 0.0}"
+            ]
+          },
+          "execution_count": 75,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "dict(zip(dv.get_feature_names_out(), model.coef_[0].round(3)))"
+      ],
+      "id": "bOYwSz5FF50B"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "iZWs75tdF50B"
+      },
+      "outputs": [],
+      "source": [
+        "small = ['contract', 'tenure', 'monthlycharges']"
+      ],
+      "id": "iZWs75tdF50B"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "AtM3QUjWF50B",
+        "outputId": "dcbbd1f7-8dcf-48e0-d6f9-0e63b68ab3dd"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "[{'contract': 'two_year', 'tenure': 72, 'monthlycharges': 115.5},\n",
+              " {'contract': 'month-to-month', 'tenure': 10, 'monthlycharges': 95.25},\n",
+              " {'contract': 'month-to-month', 'tenure': 5, 'monthlycharges': 75.55},\n",
+              " {'contract': 'month-to-month', 'tenure': 5, 'monthlycharges': 80.85},\n",
+              " {'contract': 'two_year', 'tenure': 18, 'monthlycharges': 20.1},\n",
+              " {'contract': 'month-to-month', 'tenure': 4, 'monthlycharges': 30.5},\n",
+              " {'contract': 'month-to-month', 'tenure': 1, 'monthlycharges': 75.1},\n",
+              " {'contract': 'month-to-month', 'tenure': 1, 'monthlycharges': 70.3},\n",
+              " {'contract': 'two_year', 'tenure': 72, 'monthlycharges': 19.75},\n",
+              " {'contract': 'month-to-month', 'tenure': 6, 'monthlycharges': 109.9}]"
+            ]
+          },
+          "execution_count": 77,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_train[small].iloc[:10].to_dict(orient='records')"
+      ],
+      "id": "AtM3QUjWF50B"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6PvhSBG0F50B"
+      },
+      "outputs": [],
+      "source": [
+        "dicts_train_small = df_train[small].to_dict(orient='records')\n",
+        "dicts_val_small = df_val[small].to_dict(orient='records')"
+      ],
+      "id": "6PvhSBG0F50B"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3TUxAZxGF50B",
+        "outputId": "b0f632e1-6c71-45a6-865f-91df1f6430ce"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "DictVectorizer(dtype=<class 'numpy.float64'>, separator='=', sort=True,\n",
+              "               sparse=False)"
+            ]
+          },
+          "execution_count": 79,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "dv_small = DictVectorizer(sparse=False)\n",
+        "dv_small.fit(dicts_train_small)"
+      ],
+      "id": "3TUxAZxGF50B"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "tjvFO0OBF50C",
+        "outputId": "7bdb1f02-c616-4b6b-dc06-0634defbc2bb"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "['contract=month-to-month',\n",
+              " 'contract=one_year',\n",
+              " 'contract=two_year',\n",
+              " 'monthlycharges',\n",
+              " 'tenure']"
+            ]
+          },
+          "execution_count": 80,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "dv_small.get_feature_names_out()"
+      ],
+      "id": "tjvFO0OBF50C"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "7RaLpukAF50C"
+      },
+      "outputs": [],
+      "source": [
+        "X_train_small = dv_small.transform(dicts_train_small)"
+      ],
+      "id": "7RaLpukAF50C"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "OqPnmSdGF50C",
+        "outputId": "e31007f4-e255-489b-f43a-17e6a37e58d8"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "LogisticRegression(C=1.0, class_weight=None, dual=False, fit_intercept=True,\n",
+              "                   intercept_scaling=1, l1_ratio=None, max_iter=100,\n",
+              "                   multi_class='warn', n_jobs=None, penalty='l2',\n",
+              "                   random_state=None, solver='lbfgs', tol=0.0001, verbose=0,\n",
+              "                   warm_start=False)"
+            ]
+          },
+          "execution_count": 82,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "model_small = LogisticRegression(solver='lbfgs')\n",
+        "model_small.fit(X_train_small, y_train)"
+      ],
+      "id": "OqPnmSdGF50C"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "UfmEVDh4F50C",
+        "outputId": "45e1db2f-7c08-4c6e-c5f1-5bd89f5ccc5b"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "-2.476775657751665"
+            ]
+          },
+          "execution_count": 83,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "w0 = model_small.intercept_[0]\n",
+        "w0"
+      ],
+      "id": "UfmEVDh4F50C"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "7ADZT7exF50C",
+        "outputId": "b2f3ffd5-db38-4de1-d605-6e9951e5a52e"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "array([ 0.97 , -0.025, -0.949,  0.027, -0.036])"
+            ]
+          },
+          "execution_count": 84,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "w = model_small.coef_[0]\n",
+        "w.round(3)"
+      ],
+      "id": "7ADZT7exF50C"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "pTeXchDAF50C",
+        "outputId": "3e75ece0-0dab-4710-ea35-8c6ba4589e3c"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'contract=month-to-month': 0.97,\n",
+              " 'contract=one_year': -0.025,\n",
+              " 'contract=two_year': -0.949,\n",
+              " 'monthlycharges': 0.027,\n",
+              " 'tenure': -0.036}"
+            ]
+          },
+          "execution_count": 85,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "dict(zip(dv_small.get_feature_names_out(), w.round(3)))"
+      ],
+      "id": "pTeXchDAF50C"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gIvGQXSlF50D",
+        "outputId": "aa5921de-9c23-4f97-ef18-71cc61c077bc"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "-3.473"
+            ]
+          },
+          "execution_count": 86,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "-2.47 + (-0.949) + 30 * 0.027 + 24 * (-0.036)"
+      ],
+      "id": "gIvGQXSlF50D"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6PYWJQNRF50D",
+        "outputId": "ef8b914d-498e-42c4-e376-09a6f616677f"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.030090303318277657"
+            ]
+          },
+          "execution_count": 87,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "sigmoid(_)"
+      ],
+      "id": "6PYWJQNRF50D"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "32IigZdBF50D"
+      },
+      "source": [
+        "## 3.12 Using the model"
+      ],
+      "id": "32IigZdBF50D"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "0kfZxwYKF50D"
+      },
+      "outputs": [],
+      "source": [
+        "dicts_full_train = df_full_train[categorical + numerical].to_dict(orient='records')"
+      ],
+      "id": "0kfZxwYKF50D"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "wm-bCWAcF50D"
+      },
+      "outputs": [],
+      "source": [
+        "dv = DictVectorizer(sparse=False)\n",
+        "X_full_train = dv.fit_transform(dicts_full_train)"
+      ],
+      "id": "wm-bCWAcF50D"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "WYx1gAn0F50D"
+      },
+      "outputs": [],
+      "source": [
+        "y_full_train = df_full_train.churn.values"
+      ],
+      "id": "WYx1gAn0F50D"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "iLgg-E4mF50D",
+        "outputId": "3f77c63b-b533-4f6a-c03c-1c3436ded20c"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "LogisticRegression(C=1.0, class_weight=None, dual=False, fit_intercept=True,\n",
+              "                   intercept_scaling=1, l1_ratio=None, max_iter=100,\n",
+              "                   multi_class='warn', n_jobs=None, penalty='l2',\n",
+              "                   random_state=None, solver='lbfgs', tol=0.0001, verbose=0,\n",
+              "                   warm_start=False)"
+            ]
+          },
+          "execution_count": 91,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "model = LogisticRegression(solver='lbfgs')\n",
+        "model.fit(X_full_train, y_full_train)"
+      ],
+      "id": "iLgg-E4mF50D"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "LElkWrYoF50E"
+      },
+      "outputs": [],
+      "source": [
+        "dicts_test = df_test[categorical + numerical].to_dict(orient='records')"
+      ],
+      "id": "LElkWrYoF50E"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "vql65wx4F50E"
+      },
+      "outputs": [],
+      "source": [
+        "X_test = dv.transform(dicts_test)"
+      ],
+      "id": "vql65wx4F50E"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "YNd6GqsGF50E"
+      },
+      "outputs": [],
+      "source": [
+        "y_pred = model.predict_proba(X_test)[:, 1]"
+      ],
+      "id": "YNd6GqsGF50E"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "8F1kBlT3F50E"
+      },
+      "outputs": [],
+      "source": [
+        "churn_decision = (y_pred >= 0.5)"
+      ],
+      "id": "8F1kBlT3F50E"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "btMlYB81F50E",
+        "outputId": "ca35a430-df12-4390-ffc9-464d2fa27ddd"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.815471965933286"
+            ]
+          },
+          "execution_count": 96,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "(churn_decision == y_test).mean()"
+      ],
+      "id": "btMlYB81F50E"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "EhlrqasIF50E",
+        "outputId": "da3ce9fd-bb2b-493b-8bba-cdf63a520baf"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "array([0, 0, 0, ..., 0, 0, 1])"
+            ]
+          },
+          "execution_count": 97,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "y_test"
+      ],
+      "id": "EhlrqasIF50E"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "h9dwbtOgF50E",
+        "outputId": "4312d7d7-9c6e-4582-f8fb-7cd3e94a07c0"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'gender': 'female',\n",
+              " 'seniorcitizen': 0,\n",
+              " 'partner': 'yes',\n",
+              " 'dependents': 'yes',\n",
+              " 'phoneservice': 'yes',\n",
+              " 'multiplelines': 'yes',\n",
+              " 'internetservice': 'fiber_optic',\n",
+              " 'onlinesecurity': 'yes',\n",
+              " 'onlinebackup': 'no',\n",
+              " 'deviceprotection': 'yes',\n",
+              " 'techsupport': 'no',\n",
+              " 'streamingtv': 'yes',\n",
+              " 'streamingmovies': 'yes',\n",
+              " 'contract': 'month-to-month',\n",
+              " 'paperlessbilling': 'yes',\n",
+              " 'paymentmethod': 'electronic_check',\n",
+              " 'tenure': 17,\n",
+              " 'monthlycharges': 104.2,\n",
+              " 'totalcharges': 1743.5}"
+            ]
+          },
+          "execution_count": 98,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "customer = dicts_test[-1]\n",
+        "customer"
+      ],
+      "id": "h9dwbtOgF50E"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "lX3wzA6cF50E"
+      },
+      "outputs": [],
+      "source": [
+        "X_small = dv.transform([customer])"
+      ],
+      "id": "lX3wzA6cF50E"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Aan28VjhF50F",
+        "outputId": "4e3ab6da-92d0-436c-c4d3-79c61177b9dd"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.5968852088293909"
+            ]
+          },
+          "execution_count": 100,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "model.predict_proba(X_small)[0, 1]"
+      ],
+      "id": "Aan28VjhF50F"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bJ0NvQgVF50F",
+        "outputId": "3f02c0d2-8439-4ca7-d5cb-d398529c8c1b"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "1"
+            ]
+          },
+          "execution_count": 101,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "y_test[-1]"
+      ],
+      "id": "bJ0NvQgVF50F"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "U-FnzjqVF50F"
+      },
+      "source": [
+        "## 3.13 Summary\n",
+        "\n",
+        "* Feature importance - risk, mutual information, correlation\n",
+        "* One-hot encoding can be implemented with `DictVectorizer`\n",
+        "* Logistic regression - linear model like linear regression\n",
+        "* Output of log reg - probability\n",
+        "* Interpretation of weights is similar to linear regression"
+      ],
+      "id": "U-FnzjqVF50F"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8cvw6qIKF50F"
+      },
+      "source": [
+        "## 3.14 Explore more\n",
+        "\n",
+        "More things\n",
+        "\n",
+        "* Try to exclude least useful features\n",
+        "\n",
+        "\n",
+        "Use scikit-learn in project of last week\n",
+        "\n",
+        "* Re-implement train/val/test split using scikit-learn in the project from the last week\n",
+        "* Also, instead of our own linear regression, use `LinearRegression` (not regularized) and `RidgeRegression` (regularized). Find the best regularization parameter for Ridge\n",
+        "\n",
+        "Other projects\n",
+        "\n",
+        "* Lead scoring - https://www.kaggle.com/ashydv/leads-dataset\n",
+        "* Default prediction - https://archive.ics.uci.edu/ml/datasets/default+of+credit+card+clients\n",
+        "\n"
+      ],
+      "id": "8cvw6qIKF50F"
     }
-   ],
-   "source": [
-    "y_test[-1]"
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.6.9"
+    },
+    "colab": {
+      "provenance": []
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.13 Summary\n",
-    "\n",
-    "* Feature importance - risk, mutual information, correlation\n",
-    "* One-hot encoding can be implemented with `DictVectorizer`\n",
-    "* Logistic regression - linear model like linear regression\n",
-    "* Output of log reg - probability\n",
-    "* Interpretation of weights is similar to linear regression"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.14 Explore more\n",
-    "\n",
-    "More things\n",
-    "\n",
-    "* Try to exclude least useful features\n",
-    "\n",
-    "\n",
-    "Use scikit-learn in project of last week\n",
-    "\n",
-    "* Re-implement train/val/test split using scikit-learn in the project from the last week\n",
-    "* Also, instead of our own linear regression, use `LinearRegression` (not regularized) and `RidgeRegression` (regularized). Find the best regularization parameter for Ridge\n",
-    "\n",
-    "Other projects\n",
-    "\n",
-    "* Lead scoring - https://www.kaggle.com/ashydv/leads-dataset\n",
-    "* Default prediction - https://archive.ics.uci.edu/ml/datasets/default+of+credit+card+clients\n",
-    "\n"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.9"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
In course 3, "03-classification",  Scikit-learn renamed `get_feature_names()` method of `DictVectorizer` (sklearn.feature_extraction) class to `get_feature_names_out()`. The `get_feature_names()` method doesn't work anymore and it has been updated on their documentation page [here](https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.DictVectorizer.html#sklearn.feature_extraction.DictVectorizer.get_feature_names_out) 